### PR TITLE
Feature - Get recurrent calendar events with CalendarView

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: ruby
+rvm:
+  - 2.3.0
 before_install:
-  - gem uninstall bundler -a
-  - gem install bundler -v 1.6.2
+  - gem install bundler -v 1.11.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+before_install:
+  - gem install bundler -v 1.6.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 before_install:
-  - gem uninstall bundler
+  - gem uninstall bundler -a
   - gem install bundler -v 1.6.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 before_install:
+  - gem uninstall bundler
   - gem install bundler -v 1.6.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
-source :rubygems
+source "https://rubygems.org/"
+
 gemspec

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Supported `CalendarView` options/attributes:
 ```ruby
 folder = Exchanger::Folder.find(:calendar, "email@example.com")
 calendar_view_options = {
-  start_date: (DateTime.now - 1.week).xmlschema,
-  end_date:   DateTime.now.xmlschema,
+  start_date: (DateTime.now - 1.week),
+  end_date:   DateTime.now,
 }
 folder.expanded_items(calendar_view_options) # return Exchanger::CalendarItem items
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Exchanger.configure do |config|
   config.endpoint = "https://domain.com/EWS/Exchanger.asmx"
   config.username = "username"
   config.password = "password"
+  config.debug = true # show Exchange request/response info
 end
 ```
 
@@ -63,6 +64,36 @@ Searching in Global Address Book
 
 ```ruby
 mailboxes = Exchanger::Mailbox.search("John")
+```
+
+Searching for Calendar items
+----------------------------
+More specific Exchange calendar documentation can be found
+[here](https://msdn.microsoft.com/en-us/library/office/dn495614(v=exchg.150).aspx).
+
+1) Return all Calendar items with recurring **master** appointments (without recurring).
+Also called as non-expanded view.
+
+```ruby
+folder = Exchanger::Folder.find(:calendar, "email@example.com")
+folder.items # return Exchanger::CalendarItem items
+```
+
+2) Return Calendar items providing
+[CalendarView](https://msdn.microsoft.com/en-us/library/microsoft.exchange.webservices.data.calendarview(v=exchg.80).aspx) (with recurring).
+
+Supported `CalendarView` options/attributes:
+* max_entries_returned
+* start_date
+* end_date
+
+```ruby
+folder = Exchanger::Folder.find(:calendar, "email@example.com")
+calendar_view_options = {
+  start_date: (DateTime.now - 1.week).xmlschema,
+  end_date:   DateTime.now.xmlschema,
+}
+folder.expanded_items(calendar_view_options) # return Exchanger::CalendarItem items
 ```
 
 Running specs with Exchange Server

--- a/lib/exchanger.rb
+++ b/lib/exchanger.rb
@@ -26,6 +26,7 @@ require "exchanger/elements/mailbox"
 require "exchanger/elements/single_recipient"
 require "exchanger/elements/attendee"
 require "exchanger/elements/complete_name"
+require "exchanger/elements/calendar_view"
 # Entry elements
 require "exchanger/elements/entry"
 require "exchanger/elements/email_address"

--- a/lib/exchanger.rb
+++ b/lib/exchanger.rb
@@ -4,6 +4,7 @@ require "base64"
 require 'kconv' # Need for rubyntlm on Ruby 1.9
 require 'tzinfo'
 
+require "active_support"
 require "active_support/core_ext"
 require "nokogiri"
 require "httpclient"

--- a/lib/exchanger/elements/base_folder.rb
+++ b/lib/exchanger/elements/base_folder.rb
@@ -57,5 +57,14 @@ module Exchanger
         item.parent_folder = self
       end
     end
+
+    # Return items (also recurring calendar items) based on
+    # provided CalendarView options
+    def items_from_calendar_view(calendar_view_options)
+      calendar_view = CalendarView.new(calendar_view_options)
+      items = Item.find_calendar_view_set_by_folder_id(id, calendar_view)
+
+      items.each { |item| item.parent_folder = self }
+    end
   end
 end

--- a/lib/exchanger/elements/base_folder.rb
+++ b/lib/exchanger/elements/base_folder.rb
@@ -60,7 +60,7 @@ module Exchanger
 
     # Return items (also recurring calendar items) based on
     # provided CalendarView options
-    def items_from_calendar_view(calendar_view_options)
+    def expanded_items(calendar_view_options)
       calendar_view = CalendarView.new(calendar_view_options)
       items = Item.find_calendar_view_set_by_folder_id(id, calendar_view)
 

--- a/lib/exchanger/elements/calendar_view.rb
+++ b/lib/exchanger/elements/calendar_view.rb
@@ -6,7 +6,7 @@ module Exchanger
   # https://msdn.microsoft.com/en-us/library/aa564515.aspx
   class CalendarView < Element
     key :max_entries_returned
-    key :start_date
-    key :end_date
+    key :start_date, type: Time
+    key :end_date, type: Time
   end
 end

--- a/lib/exchanger/elements/calendar_view.rb
+++ b/lib/exchanger/elements/calendar_view.rb
@@ -1,0 +1,12 @@
+module Exchanger
+  # The CalendarView element defines a FindItem operation
+  # as returning calendar items in a set as they appear in a calendar.
+  # <CalendarView MaxEntriesReturned="" StartDate="" EndDate="" />
+
+  # https://msdn.microsoft.com/en-us/library/aa564515.aspx
+  class CalendarView < Element
+    key :max_entries_returned
+    key :start_date
+    key :end_date
+  end
+end

--- a/lib/exchanger/elements/item.rb
+++ b/lib/exchanger/elements/item.rb
@@ -51,6 +51,15 @@ module Exchanger
       response.items
     end
 
+    def self.find_calendar_view_set_by_folder_id(folder_id, calendar_view)
+      response = FindItem.run(
+        folder_id:     folder_id,
+        calendar_view: calendar_view,
+      )
+
+      response.items
+    end
+
     attr_writer :parent_folder
 
     def parent_folder

--- a/lib/exchanger/operations/find_item.rb
+++ b/lib/exchanger/operations/find_item.rb
@@ -4,7 +4,7 @@ module Exchanger
   # http://msdn.microsoft.com/en-us/library/aa566107.aspx
   class FindItem < Operation
     class Request < Operation::Request
-      attr_accessor :folder_id, :traversal, :base_shape, :email_address
+      attr_accessor :folder_id, :traversal, :base_shape, :email_address, :calendar_view
 
       # Reset request options to defaults.
       def reset
@@ -12,6 +12,7 @@ module Exchanger
         @traversal = :shallow
         @base_shape = :all_properties
         @email_address = nil
+        @calendar_view = nil
       end
 
       def to_xml
@@ -21,6 +22,9 @@ module Exchanger
               xml.FindItem("xmlns" => NS["m"], "xmlns:t" => NS["t"], "Traversal" => traversal.to_s.camelize) do
                 xml.ItemShape do
                   xml.send "t:BaseShape", base_shape.to_s.camelize
+                end
+                if calendar_view
+                  xml.CalendarView(calendar_view.to_xml.attributes)
                 end
                 xml.ParentFolderIds do
                   if folder_id.is_a?(Symbol)

--- a/lib/exchanger/version.rb
+++ b/lib/exchanger/version.rb
@@ -1,3 +1,3 @@
 module Exchanger
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/lib/exchanger/version.rb
+++ b/lib/exchanger/version.rb
@@ -1,3 +1,3 @@
 module Exchanger
-  VERSION = "0.1.4"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Original `BaseFolder#items` method was returning all calendar items and only `recurring master`.
To get from Exchange also recurring items `CalendarView` with `StartDate ` & `EndDate` attributes should be provided.

Here is more info about `CalendarView`: https://msdn.microsoft.com/en-us/library/aa564515.aspx

These changes add new method `BaseFolder#items_from_calendar_view` to which user must provide necessary `CalendarView` parameters. Exchange server will calculate all items (also recurring) for provided start & end date and return them.