### PR TITLE
Calendar Item Updates

### DIFF
--- a/exchanger.gemspec
+++ b/exchanger.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov"
   s.add_development_dependency "yard"
   s.add_development_dependency "BlueCloth" # required by yard
-  s.add_development_dependency "vcr", ["~> 2.2.5"]
+  s.add_development_dependency "vcr", ["~> 3.0.1"]
   s.add_development_dependency "webmock", ["~> 1.8.11"]
 
   s.files          = Dir.glob("{lib,spec}/**/*") + %w(README.md LICENSE)

--- a/lib/exchanger.rb
+++ b/lib/exchanger.rb
@@ -27,6 +27,7 @@ require "exchanger/elements/single_recipient"
 require "exchanger/elements/attendee"
 require "exchanger/elements/complete_name"
 require "exchanger/elements/calendar_view"
+require "exchanger/elements/body"
 # Entry elements
 require "exchanger/elements/entry"
 require "exchanger/elements/email_address"
@@ -82,7 +83,7 @@ module Exchanger
       config = Config.instance
       block_given? ? yield(config) : config
     end
-    
+
     alias :config :configure
   end
 end

--- a/lib/exchanger/elements/body.rb
+++ b/lib/exchanger/elements/body.rb
@@ -1,0 +1,21 @@
+module Exchanger
+  # The Body element represents the body of and item.
+  #
+  # Body:     https://msdn.microsoft.com/en-us/library/office/jj219983(v=exchg.150).aspx
+  # BodyType: https://msdn.microsoft.com/en-us/library/office/aa565622(v=exchg.150).aspx
+  class Body < Element
+    element :body_type  # "HTML" or "Text" (or "Best" during retrieval only)
+    element :is_truncated, type: Boolean
+
+    element :text
+
+    def to_xml(options = {})
+      doc = Nokogiri::XML::Document.new
+      body_attributes = { "BodyType" => body_type || "Text" }
+      body_attributes["IsTruncated"] = is_truncated if is_truncated
+      root = doc.create_element(tag_name, body_attributes)
+      root << doc.create_text_node(text.to_s)
+      root
+    end
+  end
+end

--- a/lib/exchanger/elements/body.rb
+++ b/lib/exchanger/elements/body.rb
@@ -1,5 +1,5 @@
 module Exchanger
-  # The Body element represents the body of and item.
+  # The Body element represents the body of an item.
   #
   # Body:     https://msdn.microsoft.com/en-us/library/office/jj219983(v=exchg.150).aspx
   # BodyType: https://msdn.microsoft.com/en-us/library/office/aa565622(v=exchg.150).aspx

--- a/lib/exchanger/elements/calendar_item.rb
+++ b/lib/exchanger/elements/calendar_item.rb
@@ -1,6 +1,6 @@
 module Exchanger
   # The CalendarItem element represents an Exchanger calendar item.
-  # 
+  #
   # http://msdn.microsoft.com/en-us/library/aa564765.aspx
   class CalendarItem < Item
     self.field_uri_namespace = :calendar
@@ -56,9 +56,12 @@ module Exchanger
     element :meeting_workspace_url
     element :net_show_url
 
-    def create
-      CreateItem.run(:folder_id => parent_folder_id.id, :items => [self],
-                     :send_meeting_invitations => "SendToAllAndSaveCopy")
+    def create_additional_options
+      { send_meeting_invitations: "SendToAllAndSaveCopy" }
+    end
+
+    def delete_additional_options
+      { send_meeting_cancellations: "SendToAllAndSaveCopy" }
     end
   end
 end

--- a/lib/exchanger/elements/calendar_item.rb
+++ b/lib/exchanger/elements/calendar_item.rb
@@ -60,6 +60,10 @@ module Exchanger
       { send_meeting_invitations: "SendToAllAndSaveCopy" }
     end
 
+    def update_additional_options
+      { send_meeting_invitations_or_cancellations: "SendToAllAndSaveCopy" }
+    end
+
     def delete_additional_options
       { send_meeting_cancellations: "SendToAllAndSaveCopy" }
     end

--- a/lib/exchanger/elements/item.rb
+++ b/lib/exchanger/elements/item.rb
@@ -72,7 +72,8 @@ module Exchanger
 
     def create
       if parent_folder_id
-        response = CreateItem.run(:folder_id => parent_folder_id.id, :items => [self])
+        options = { folder_id: parent_folder_id.id, items: [self] }.merge(create_additional_options)
+        response = CreateItem.run(options)
         self.item_id = response.item_ids[0]
         move_changes
         true
@@ -80,6 +81,10 @@ module Exchanger
         errors << "Parent folder can't be blank"
         false
       end
+    end
+
+    def create_additional_options
+      {}  # Implement in subclasses to add CreateItem options
     end
 
     def update
@@ -93,11 +98,16 @@ module Exchanger
     end
 
     def delete
-      if DeleteItem.run(:item_ids => [id])
+      options = { item_ids: [id] }.merge(delete_additional_options)
+      if DeleteItem.run(options)
         true
       else
         false
       end
+    end
+
+    def delete_additional_options
+      {}  # Implement in subclasses to add DeleteItem options
     end
   end
 end

--- a/lib/exchanger/elements/item.rb
+++ b/lib/exchanger/elements/item.rb
@@ -9,7 +9,7 @@ module Exchanger
     element :item_class
     element :subject
     element :sensitivity
-    element :body
+    element :body, type: Body
     element :attachments, :type => [String]
     element :date_time_received, :type => Time
     element :size, :type => Integer

--- a/lib/exchanger/elements/item.rb
+++ b/lib/exchanger/elements/item.rb
@@ -99,7 +99,7 @@ module Exchanger
     end
 
     def update_additional_options
-      {}  # Implement in subclasses to add CreateItem options
+      {}  # Implement in subclasses to add UpdateItem options
     end
 
     def delete

--- a/lib/exchanger/elements/item.rb
+++ b/lib/exchanger/elements/item.rb
@@ -89,12 +89,17 @@ module Exchanger
 
     def update
       if changed?
-        response = UpdateItem.run(:items => [self])
+        options = { items: [self] }.merge(update_additional_options)
+        response = UpdateItem.run(options)
         move_changes
         true
       else
         true
       end
+    end
+
+    def update_additional_options
+      {}  # Implement in subclasses to add CreateItem options
     end
 
     def delete

--- a/lib/exchanger/operations/create_item.rb
+++ b/lib/exchanger/operations/create_item.rb
@@ -1,13 +1,13 @@
 module Exchanger
   # The CreateItem operation creates items in the Exchanger store.
-  # 
+  #
   # You can use the CreateItem operation to create the following:
   # * Calendar items
   # * E-mail messages
   # * Meeting requests
   # * Tasks
   # * Contacts
-  # 
+  #
   # http://msdn.microsoft.com/en-us/library/aa563797.aspx
   class CreateItem < Operation
     class Request < Operation::Request
@@ -25,8 +25,7 @@ module Exchanger
         Nokogiri::XML::Builder.new do |xml|
           xml.send("soap:Envelope", "xmlns:soap" => NS["soap"], "xmlns:t" => NS["t"], "xmlns:xsi" => NS["xsi"], "xmlns:xsd" => NS["xsd"]) do
             xml.send("soap:Body") do
-              xml.CreateItem("xmlns" => NS["m"],
-                            'SendMeetingInvitations' => send_meeting_invitations) do
+              xml.CreateItem(create_item_attributes) do
                 xml.SavedItemFolderId do
                   if folder_id.is_a?(Symbol)
                     xml.send("t:DistinguishedFolderId", "Id" => folder_id) do
@@ -53,6 +52,14 @@ module Exchanger
           end
         end
       end
+
+      private
+
+        def create_item_attributes
+          create_item_attributes = { "xmlns" => NS["m"] }
+          create_item_attributes["SendMeetingInvitations"] = send_meeting_invitations if send_meeting_invitations
+          create_item_attributes
+        end
     end
 
     class Response < Operation::Response

--- a/lib/exchanger/operations/delete_item.rb
+++ b/lib/exchanger/operations/delete_item.rb
@@ -1,17 +1,17 @@
 module Exchanger
   # The DeleteItem operation deletes items in the Exchanger store.
-  # 
+  #
   # You can use the DeleteItem operation to delete the following:
   # * Calendar items
   # * E-mail messages
   # * Meeting requests
   # * Tasks
   # * Contacts
-  # 
+  #
   # http://msdn.microsoft.com/en-us/library/aa580484.aspx
   class DeleteItem < Operation
     class Request < Operation::Request
-      attr_accessor :item_ids
+      attr_accessor :item_ids, :send_meeting_cancellations
 
       # Reset request options to defaults.
       def reset
@@ -22,7 +22,7 @@ module Exchanger
         Nokogiri::XML::Builder.new do |xml|
           xml.send("soap:Envelope", "xmlns:soap" => NS["soap"], "xmlns:t" => NS["t"], "xmlns:xsi" => NS["xsi"], "xmlns:xsd" => NS["xsd"]) do
             xml.send("soap:Body") do
-              xml.DeleteItem("xmlns" => NS["m"], "DeleteType" => "HardDelete") do
+              xml.DeleteItem(delete_item_attributes) do
                 xml.ItemIds do
                   item_ids.each do |item_id|
                     xml["t"].ItemId("Id" => item_id)
@@ -33,6 +33,14 @@ module Exchanger
           end
         end
       end
+
+      private
+
+        def delete_item_attributes
+          delete_item_attributes = { "xmlns" => NS["m"], "DeleteType" => "HardDelete" }
+          delete_item_attributes["SendMeetingCancellations"] = send_meeting_cancellations if send_meeting_cancellations
+          delete_item_attributes
+        end
     end
 
     class Response < Operation::Response

--- a/lib/exchanger/operations/update_item.rb
+++ b/lib/exchanger/operations/update_item.rb
@@ -1,11 +1,11 @@
 module Exchanger
   # The UpdateItem operation is used to modify the properties of an existing item in the Exchanger store.
-  # 
+  #
   # http://msdn.microsoft.com/en-us/library/aa581084.aspx
   # http://msdn.microsoft.com/en-us/library/aa579673.aspx
   class UpdateItem < Operation
     class Request < Operation::Request
-      attr_accessor :items
+      attr_accessor :items, :send_meeting_invitations_or_cancellations
 
       # Reset request options to defaults.
       def reset
@@ -16,7 +16,7 @@ module Exchanger
         Nokogiri::XML::Builder.new do |xml|
           xml.send("soap:Envelope", "xmlns:soap" => NS["soap"], "xmlns:t" => NS["t"], "xmlns:xsi" => NS["xsi"], "xmlns:xsd" => NS["xsd"]) do
             xml.send("soap:Body") do
-              xml.UpdateItem("xmlns" => NS["m"], "ConflictResolution" => "AlwaysOverwrite") do
+              xml.UpdateItem(update_item_attributes) do
                 xml.ItemChanges do
                   items.each do |item|
                     item_change = item.to_xml_change
@@ -30,6 +30,14 @@ module Exchanger
           end
         end
       end
+
+      private
+
+        def update_item_attributes
+          update_item_attributes = { "xmlns" => NS["m"], "ConflictResolution" => "AlwaysOverwrite" }
+          update_item_attributes["SendMeetingInvitationsOrCancellations"] = send_meeting_invitations_or_cancellations if send_meeting_invitations_or_cancellations
+          update_item_attributes
+        end
     end
 
     class Response < Operation::Response

--- a/spec/cassettes/calendar_item/save.yml
+++ b/spec/cassettes/calendar_item/save.yml
@@ -1,0 +1,344 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Body>
+            <FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" Traversal="Shallow">
+              <ItemShape>
+                <t:BaseShape>AllProperties</t:BaseShape>
+              </ItemShape>
+              <ParentFolderIds>
+                <t:FolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"/>
+              </ParentFolderIds>
+            </FindItem>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/FindItem
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - c5aaa209-0527-42b9-9c4d-689c4a66a84e
+      X-Calculatedbetarget:
+      - BY2PR08MB046.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=c5453986db0f425b99a5cd9d00c7a504; expires=Sat, 06-May-2017
+        19:42:17 GMT; path=/; HttpOnly
+      X-Ewshandler:
+      - FindItem
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - BY2PR08MB046
+      X-Beserver:
+      - BY2PR08MB046
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - BLUPR14CA0071
+      Date:
+      - Fri, 06 May 2016 19:42:17 GMT
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:FindItemResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:FindItemResponseMessage
+        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootFolder
+        TotalItemsInView="2" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjbAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABl4"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
+        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T18:40:30Z</t:DateTimeReceived><t:Size>3871</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T18:40:30Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T18:40:30Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T18:40:26Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T18:40:26Z</t:Start><t:End>2016-05-06T19:10:26Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>FIRST_NAME
+        FIRST_NAME LAST_NAME</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE
+        ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
+        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem><t:CalendarItem><t:ItemId
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjaAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABl2"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Appointment
+        Title</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T16:11:42Z</t:DateTimeReceived><t:Size>5926</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T16:11:42Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T16:11:42Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T15:00:00Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T15:00:00Z</t:Start><t:End>2016-05-06T15:30:00Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:Location>Test
+        Location</t:Location><t:IsMeeting>false</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>FIRST_NAME
+        FIRST_NAME LAST_NAME</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE
+        ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC-06:00)
+        Central Time (US &amp; Canada)</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>0</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Fri, 06 May 2016 19:42:17 GMT
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body>
+            <CreateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" SendMeetingInvitations="SendToAllAndSaveCopy">
+              <SavedItemFolderId>
+                <t:FolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"/>
+              </SavedItemFolderId>
+              <Items>
+                <t:CalendarItem>
+          <t:Subject>Calendar Item Subject</t:Subject>
+          <t:Start>2016-05-06T14:42:17-05:00</t:Start>
+          <t:End>2016-05-06T15:12:17-05:00</t:End>
+        </t:CalendarItem>
+              </Items>
+            </CreateItem>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/CreateItem
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - 2fd90aef-12f9-4f3a-b9a2-91ef1f60f841
+      X-Calculatedbetarget:
+      - BY2PR08MB046.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=c3a544ae3d8f425b934940045a0c192b; expires=Sat, 06-May-2017
+        19:42:18 GMT; path=/; HttpOnly
+      X-Ewshandler:
+      - CreateItem
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - BY2PR08MB046
+      X-Beserver:
+      - BY2PR08MB046
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - DM3PR12CA0013
+      Date:
+      - Fri, 06 May 2016 19:42:17 GMT
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:CreateItemResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:CreateItemResponseMessage
+        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjlAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmV"/></t:CalendarItem></m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Fri, 06 May 2016 19:42:18 GMT
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Body>
+            <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+              <ItemShape>
+                <t:BaseShape>AllProperties</t:BaseShape>
+              </ItemShape>
+              <ItemIds>
+                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjlAAAA"/>
+              </ItemIds>
+            </GetItem>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/GetItem
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - e16910f5-65ed-4363-a51a-c468aa19f987
+      X-Calculatedbetarget:
+      - BY2PR08MB046.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=9eee39ad466c4a7e9c03db9ebf43b416; expires=Sat, 06-May-2017
+        19:42:19 GMT; path=/; HttpOnly
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - BY2PR08MB046
+      X-Beserver:
+      - BY2PR08MB046
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - DM3PR20CA0030
+      Date:
+      - Fri, 06 May 2016 19:42:19 GMT
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetItemResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetItemResponseMessage
+        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjlAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmV"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
+        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:Body BodyType="Text"/><t:DateTimeReceived>2016-05-06T19:42:18Z</t:DateTimeReceived><t:Size>3823</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T19:42:18Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T19:42:18Z</t:DateTimeCreated><t:ResponseObjects><t:CancelCalendarItem/><t:ForwardItem/></t:ResponseObjects><t:ReminderDueBy>2016-05-06T19:42:17Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:DisplayCc/><t:DisplayTo/><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T19:42:17Z</t:Start><t:End>2016-05-06T20:12:17Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
+        SpecTester</t:Name><t:EmailAddress>FILTERED_EMAIL_ADDRESS</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
+        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Fri, 06 May 2016 19:42:19 GMT
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Body>
+            <FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" Traversal="Shallow">
+              <ItemShape>
+                <t:BaseShape>AllProperties</t:BaseShape>
+              </ItemShape>
+              <ParentFolderIds>
+                <t:FolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"/>
+              </ParentFolderIds>
+            </FindItem>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/FindItem
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - 9819ce35-f238-4818-9937-3812c0aeecfd
+      X-Calculatedbetarget:
+      - BY2PR08MB046.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=75020fdb927c48a598e69d9d8cec33ce; expires=Sat, 06-May-2017
+        19:42:19 GMT; path=/; HttpOnly
+      X-Ewshandler:
+      - FindItem
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - BY2PR08MB046
+      X-Beserver:
+      - BY2PR08MB046
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - DM2PR10CA0054
+      Date:
+      - Fri, 06 May 2016 19:42:20 GMT
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:FindItemResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:FindItemResponseMessage
+        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootFolder
+        TotalItemsInView="3" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjlAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmV"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
+        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T19:42:18Z</t:DateTimeReceived><t:Size>3823</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T19:42:18Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T19:42:18Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T19:42:17Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T19:42:17Z</t:Start><t:End>2016-05-06T20:12:17Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
+        SpecTester</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE ADMINISTRATIVE
+        GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
+        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem><t:CalendarItem><t:ItemId
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjbAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABl4"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
+        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T18:40:30Z</t:DateTimeReceived><t:Size>3871</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T18:40:30Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T18:40:30Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T18:40:26Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T18:40:26Z</t:Start><t:End>2016-05-06T19:10:26Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>FIRST_NAME
+        FIRST_NAME LAST_NAME</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE
+        ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
+        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem><t:CalendarItem><t:ItemId
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjaAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABl2"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Appointment
+        Title</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T16:11:42Z</t:DateTimeReceived><t:Size>5926</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T16:11:42Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T16:11:42Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T15:00:00Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T15:00:00Z</t:Start><t:End>2016-05-06T15:30:00Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:Location>Test
+        Location</t:Location><t:IsMeeting>false</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>FIRST_NAME
+        FIRST_NAME LAST_NAME</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE
+        ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC-06:00)
+        Central Time (US &amp; Canada)</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>0</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Fri, 06 May 2016 19:42:20 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/calendar_item/save.yml
+++ b/spec/cassettes/calendar_item/save.yml
@@ -40,14 +40,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 0a98aa17-9295-44f9-a4a0-bb9c4629afd7
+      - b981dd77-d847-45e5-85ab-81dc70709e20
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=ff7dcf5548f24c88a52f150567f150bb; expires=Sat, 06-May-2017
-        20:30:15 GMT; path=/; HttpOnly
+      - exchangecookie=a9aba4f46acd4fa29eb5d8a6609e27a3; expires=Sat, 06-May-2017
+        20:40:50 GMT; path=/; HttpOnly
       X-Ewshandler:
       - FindItem
       X-Aspnet-Version:
@@ -59,9 +59,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - CY1PR21CA0018
+      - CO2PR05CA018
       Date:
-      - Fri, 06 May 2016 20:30:15 GMT
+      - Fri, 06 May 2016 20:40:50 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -81,7 +81,7 @@ http_interactions:
         ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC-06:00)
         Central Time (US &amp; Canada)</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>0</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:30:15 GMT
+  recorded_at: Fri, 06 May 2016 20:40:50 GMT
 - request:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
@@ -100,8 +100,8 @@ http_interactions:
           <t:Subject>Calendar Item Subject</t:Subject>
           <t:Body BodyType="Text">Body line 1.
         Body line 2.</t:Body>
-          <t:Start>2016-05-06T15:30:15-05:00</t:Start>
-          <t:End>2016-05-06T16:00:15-05:00</t:End>
+          <t:Start>2016-05-06T15:40:50-05:00</t:Start>
+          <t:End>2016-05-06T16:10:50-05:00</t:End>
         </t:CalendarItem>
               </Items>
             </CreateItem>
@@ -128,14 +128,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 6c3b2fdd-4682-4f8c-9b56-e19eaa2e1914
+      - 7b713560-4651-47a6-8a25-338bac6a82ca
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=1a9feb93c2ea4add99dacc8d1ab9a70b; expires=Sat, 06-May-2017
-        20:30:16 GMT; path=/; HttpOnly
+      - exchangecookie=66c0312f118e4c378522e04054a31a99; expires=Sat, 06-May-2017
+        20:40:50 GMT; path=/; HttpOnly
       X-Ewshandler:
       - CreateItem
       X-Aspnet-Version:
@@ -147,9 +147,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - BY1PR10CA0016
+      - BY2PR08CA027
       Date:
-      - Fri, 06 May 2016 20:30:16 GMT
+      - Fri, 06 May 2016 20:40:50 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -159,10 +159,10 @@ http_interactions:
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:CreateItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjrAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmo"/></t:CalendarItem></m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse></s:Body></s:Envelope>
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmz"/></t:CalendarItem></m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:30:16 GMT
+  recorded_at: Fri, 06 May 2016 20:40:51 GMT
 - request:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
@@ -177,7 +177,7 @@ http_interactions:
                 <t:BaseShape>AllProperties</t:BaseShape>
               </ItemShape>
               <ItemIds>
-                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjrAAAA"/>
+                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA"/>
               </ItemIds>
             </GetItem>
           </soap:Body>
@@ -203,14 +203,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - db63a11d-2aa3-4afd-9f6e-1aaab4c635b9
+      - e68d1986-0aaa-49f4-a084-c503cdd7883c
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=259ccaa2fbcd4234b2884d6b0caa951a; expires=Sat, 06-May-2017
-        20:30:16 GMT; path=/; HttpOnly
+      - exchangecookie=0491af8280f347e39f610215205282ac; expires=Sat, 06-May-2017
+        20:40:51 GMT; path=/; HttpOnly
       X-Aspnet-Version:
       - 4.0.30319
       X-Diaginfo:
@@ -220,16 +220,16 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - BLUPR0601CA0027
+      - CY1PR16CA0017
       Date:
-      - Fri, 06 May 2016 20:30:16 GMT
+      - Fri, 06 May 2016 20:40:51 GMT
     body:
       encoding: UTF-8
       string: |-
-        <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjrAAAA" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmo"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA" ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:Body BodyType="Text">Body line 1.
-        Body line 2.</t:Body><t:DateTimeReceived>2016-05-06T20:30:16Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T20:30:16Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T20:30:16Z</t:DateTimeCreated><t:ResponseObjects><t:CancelCalendarItem/><t:ForwardItem/></t:ResponseObjects><t:ReminderDueBy>2016-05-06T20:30:15Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:DisplayCc/><t:DisplayTo/><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T20:30:15Z</t:Start><t:End>2016-05-06T21:00:15Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger SpecTester</t:Name><t:EmailAddress>FILTERED_EMAIL_ADDRESS</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC) Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse></s:Body></s:Envelope>
+        <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmz"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA" ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:Body BodyType="Text">Body line 1.
+        Body line 2.</t:Body><t:DateTimeReceived>2016-05-06T20:40:51Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T20:40:51Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T20:40:51Z</t:DateTimeCreated><t:ResponseObjects><t:CancelCalendarItem/><t:ForwardItem/></t:ResponseObjects><t:ReminderDueBy>2016-05-06T20:40:50Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:DisplayCc/><t:DisplayTo/><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T20:40:50Z</t:Start><t:End>2016-05-06T21:10:50Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger SpecTester</t:Name><t:EmailAddress>FILTERED_EMAIL_ADDRESS</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC) Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:30:17 GMT
+  recorded_at: Fri, 06 May 2016 20:40:51 GMT
 - request:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
@@ -270,14 +270,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 70b0b0c7-53b2-4818-af89-d6986829b6ee
+      - 9c5a893e-42c8-45fb-bca9-5fce2775aa06
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=ce980adb9d8b423e912602381b3207af; expires=Sat, 06-May-2017
-        20:30:17 GMT; path=/; HttpOnly
+      - exchangecookie=7e59b0658cf0452ca79ef3b5c5bd2506; expires=Sat, 06-May-2017
+        20:40:52 GMT; path=/; HttpOnly
       X-Ewshandler:
       - FindItem
       X-Aspnet-Version:
@@ -289,9 +289,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - BY1PR19CA0005
+      - CY1PR16CA0021
       Date:
-      - Fri, 06 May 2016 20:30:17 GMT
+      - Fri, 06 May 2016 20:40:52 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -302,10 +302,10 @@ http_interactions:
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:FindItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootFolder
         TotalItemsInView="2" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjrAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmo"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmz"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
         ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
-        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T20:30:16Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T20:30:16Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T20:30:16Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T20:30:15Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T20:30:15Z</t:Start><t:End>2016-05-06T21:00:15Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
+        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T20:40:51Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T20:40:51Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T20:40:51Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T20:40:50Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T20:40:50Z</t:Start><t:End>2016-05-06T21:10:50Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
         SpecTester</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE ADMINISTRATIVE
         GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
         Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem><t:CalendarItem><t:ItemId
@@ -318,5 +318,87 @@ http_interactions:
         ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC-06:00)
         Central Time (US &amp; Canada)</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>0</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:30:17 GMT
+  recorded_at: Fri, 06 May 2016 20:40:52 GMT
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body>
+            <UpdateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" ConflictResolution="AlwaysOverwrite" SendMeetingInvitationsOrCancellations="SendToAllAndSaveCopy">
+              <ItemChanges>
+                <t:ItemChange>
+          <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmz"/>
+          <t:Updates>
+            <t:SetItemField>
+              <t:FieldURI FieldURI="item:Subject"/>
+              <t:CalendarItem>
+                <t:Subject>Calendar Item Subject - Updated</t:Subject>
+              </t:CalendarItem>
+            </t:SetItemField>
+          </t:Updates>
+        </t:ItemChange>
+              </ItemChanges>
+            </UpdateItem>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/UpdateItem
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - a9971799-c52c-447c-a11c-14f3c053c98e
+      X-Calculatedbetarget:
+      - BY2PR08MB046.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=ccdad5a4b48348b796b5474dc56cef29; expires=Sat, 06-May-2017
+        20:40:53 GMT; path=/; HttpOnly
+      X-Ewshandler:
+      - UpdateItem
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - BY2PR08MB046
+      X-Beserver:
+      - BY2PR08MB046
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - CY1PR17CA0023
+      Date:
+      - Fri, 06 May 2016 20:40:52 GMT
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:UpdateItemResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:UpdateItemResponseMessage
+        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABm1"/></t:CalendarItem></m:Items></m:UpdateItemResponseMessage></m:ResponseMessages></m:UpdateItemResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Fri, 06 May 2016 20:40:53 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/calendar_item/save.yml
+++ b/spec/cassettes/calendar_item/save.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
     body:
       encoding: UTF-8
       string: |
@@ -40,14 +40,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - b981dd77-d847-45e5-85ab-81dc70709e20
+      - 78b66928-80a4-48f0-8ccd-403018a99bae
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=a9aba4f46acd4fa29eb5d8a6609e27a3; expires=Sat, 06-May-2017
-        20:40:50 GMT; path=/; HttpOnly
+      - exchangecookie=484d62f46101483db34928b7525f50e6; expires=Tue, 09-May-2017
+        16:00:05 GMT; path=/; HttpOnly
       X-Ewshandler:
       - FindItem
       X-Aspnet-Version:
@@ -59,9 +59,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - CO2PR05CA018
+      - BY2PR16CA0015
       Date:
-      - Fri, 06 May 2016 20:40:50 GMT
+      - Mon, 09 May 2016 16:00:04 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -71,20 +71,12 @@ http_interactions:
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:FindItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootFolder
-        TotalItemsInView="1" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjaAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABl2"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
-        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Appointment
-        Title</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T16:11:42Z</t:DateTimeReceived><t:Size>5926</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T16:11:42Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T16:11:42Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T15:00:00Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T15:00:00Z</t:Start><t:End>2016-05-06T15:30:00Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:Location>Test
-        Location</t:Location><t:IsMeeting>false</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>FIRST_NAME
-        FIRST_NAME LAST_NAME</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE
-        ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC-06:00)
-        Central Time (US &amp; Canada)</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>0</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
+        TotalItemsInView="0" IncludesLastItemInRange="true"><t:Items/></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:40:50 GMT
+  recorded_at: Mon, 09 May 2016 16:00:05 GMT
 - request:
     method: post
-    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
     body:
       encoding: UTF-8
       string: |
@@ -100,8 +92,8 @@ http_interactions:
           <t:Subject>Calendar Item Subject</t:Subject>
           <t:Body BodyType="Text">Body line 1.
         Body line 2.</t:Body>
-          <t:Start>2016-05-06T15:40:50-05:00</t:Start>
-          <t:End>2016-05-06T16:10:50-05:00</t:End>
+          <t:Start>2016-05-09T11:00:05-05:00</t:Start>
+          <t:End>2016-05-09T11:30:05-05:00</t:End>
         </t:CalendarItem>
               </Items>
             </CreateItem>
@@ -128,14 +120,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 7b713560-4651-47a6-8a25-338bac6a82ca
+      - 89c8e07e-05f2-4e45-902d-277f996d26ee
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=66c0312f118e4c378522e04054a31a99; expires=Sat, 06-May-2017
-        20:40:50 GMT; path=/; HttpOnly
+      - exchangecookie=00047aa713014d7eb7c0e8409ce35415; expires=Tue, 09-May-2017
+        16:00:06 GMT; path=/; HttpOnly
       X-Ewshandler:
       - CreateItem
       X-Aspnet-Version:
@@ -147,9 +139,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - BY2PR08CA027
+      - CO2PR07CA0003
       Date:
-      - Fri, 06 May 2016 20:40:50 GMT
+      - Mon, 09 May 2016 16:00:05 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -159,13 +151,13 @@ http_interactions:
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:CreateItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmz"/></t:CalendarItem></m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse></s:Body></s:Envelope>
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABnp"/></t:CalendarItem></m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:40:51 GMT
+  recorded_at: Mon, 09 May 2016 16:00:06 GMT
 - request:
     method: post
-    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
     body:
       encoding: UTF-8
       string: |
@@ -177,7 +169,7 @@ http_interactions:
                 <t:BaseShape>AllProperties</t:BaseShape>
               </ItemShape>
               <ItemIds>
-                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA"/>
+                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA"/>
               </ItemIds>
             </GetItem>
           </soap:Body>
@@ -203,14 +195,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - e68d1986-0aaa-49f4-a084-c503cdd7883c
+      - 996d9cc2-cd10-4358-b933-e9d745d9dbf8
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=0491af8280f347e39f610215205282ac; expires=Sat, 06-May-2017
-        20:40:51 GMT; path=/; HttpOnly
+      - exchangecookie=de130f3131f94c48a0ed6b538f3fa209; expires=Tue, 09-May-2017
+        16:00:06 GMT; path=/; HttpOnly
       X-Aspnet-Version:
       - 4.0.30319
       X-Diaginfo:
@@ -220,19 +212,19 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - CY1PR16CA0017
+      - CO2PR07CA0006
       Date:
-      - Fri, 06 May 2016 20:40:51 GMT
+      - Mon, 09 May 2016 16:00:06 GMT
     body:
       encoding: UTF-8
       string: |-
-        <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmz"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA" ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:Body BodyType="Text">Body line 1.
-        Body line 2.</t:Body><t:DateTimeReceived>2016-05-06T20:40:51Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T20:40:51Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T20:40:51Z</t:DateTimeCreated><t:ResponseObjects><t:CancelCalendarItem/><t:ForwardItem/></t:ResponseObjects><t:ReminderDueBy>2016-05-06T20:40:50Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:DisplayCc/><t:DisplayTo/><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T20:40:50Z</t:Start><t:End>2016-05-06T21:10:50Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger SpecTester</t:Name><t:EmailAddress>FILTERED_EMAIL_ADDRESS</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC) Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse></s:Body></s:Envelope>
+        <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABnp"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA" ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:Body BodyType="Text">Body line 1.
+        Body line 2.</t:Body><t:DateTimeReceived>2016-05-09T16:00:06Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-09T16:00:06Z</t:DateTimeSent><t:DateTimeCreated>2016-05-09T16:00:06Z</t:DateTimeCreated><t:ResponseObjects><t:CancelCalendarItem/><t:ForwardItem/></t:ResponseObjects><t:ReminderDueBy>2016-05-09T16:00:05Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:DisplayCc/><t:DisplayTo/><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-09T16:00:05Z</t:Start><t:End>2016-05-09T16:30:05Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger SpecTester</t:Name><t:EmailAddress>FILTERED_EMAIL_ADDRESS</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC) Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:40:51 GMT
+  recorded_at: Mon, 09 May 2016 16:00:06 GMT
 - request:
     method: post
-    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
     body:
       encoding: UTF-8
       string: |
@@ -270,14 +262,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 9c5a893e-42c8-45fb-bca9-5fce2775aa06
+      - f61fc06d-7c71-474d-ad95-48c1007a4730
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=7e59b0658cf0452ca79ef3b5c5bd2506; expires=Sat, 06-May-2017
-        20:40:52 GMT; path=/; HttpOnly
+      - exchangecookie=dcc2b32cb962435c9ab071e44abf18a1; expires=Tue, 09-May-2017
+        16:00:07 GMT; path=/; HttpOnly
       X-Ewshandler:
       - FindItem
       X-Aspnet-Version:
@@ -289,9 +281,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - CY1PR16CA0021
+      - BY2PR13CA0003
       Date:
-      - Fri, 06 May 2016 20:40:52 GMT
+      - Mon, 09 May 2016 16:00:07 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -301,27 +293,19 @@ http_interactions:
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:FindItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootFolder
-        TotalItemsInView="2" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmz"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        TotalItemsInView="1" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABnp"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
         ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
-        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T20:40:51Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T20:40:51Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T20:40:51Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T20:40:50Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T20:40:50Z</t:Start><t:End>2016-05-06T21:10:50Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
+        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-09T16:00:06Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-09T16:00:06Z</t:DateTimeSent><t:DateTimeCreated>2016-05-09T16:00:06Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-09T16:00:05Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-09T16:00:05Z</t:Start><t:End>2016-05-09T16:30:05Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
         SpecTester</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE ADMINISTRATIVE
         GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
-        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjaAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABl2"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
-        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Appointment
-        Title</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T16:11:42Z</t:DateTimeReceived><t:Size>5926</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T16:11:42Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T16:11:42Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T15:00:00Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T15:00:00Z</t:Start><t:End>2016-05-06T15:30:00Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:Location>Test
-        Location</t:Location><t:IsMeeting>false</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>FIRST_NAME
-        FIRST_NAME LAST_NAME</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE
-        ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC-06:00)
-        Central Time (US &amp; Canada)</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>0</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
+        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:40:52 GMT
+  recorded_at: Mon, 09 May 2016 16:00:07 GMT
 - request:
     method: post
-    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
     body:
       encoding: UTF-8
       string: |
@@ -331,7 +315,7 @@ http_interactions:
             <UpdateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" ConflictResolution="AlwaysOverwrite" SendMeetingInvitationsOrCancellations="SendToAllAndSaveCopy">
               <ItemChanges>
                 <t:ItemChange>
-          <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmz"/>
+          <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABnp"/>
           <t:Updates>
             <t:SetItemField>
               <t:FieldURI FieldURI="item:Subject"/>
@@ -366,14 +350,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - a9971799-c52c-447c-a11c-14f3c053c98e
+      - 8bf1efd8-64fc-41fc-9eb8-931141846e64
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=ccdad5a4b48348b796b5474dc56cef29; expires=Sat, 06-May-2017
-        20:40:53 GMT; path=/; HttpOnly
+      - exchangecookie=d1acd3cb14304f67b34e27caa30c26ca; expires=Tue, 09-May-2017
+        16:00:07 GMT; path=/; HttpOnly
       X-Ewshandler:
       - UpdateItem
       X-Aspnet-Version:
@@ -385,9 +369,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - CY1PR17CA0023
+      - CY1PR21CA0005
       Date:
-      - Fri, 06 May 2016 20:40:52 GMT
+      - Mon, 09 May 2016 16:00:07 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -397,8 +381,8 @@ http_interactions:
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:UpdateItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABm1"/></t:CalendarItem></m:Items></m:UpdateItemResponseMessage></m:ResponseMessages></m:UpdateItemResponse></s:Body></s:Envelope>
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABnr"/></t:CalendarItem></m:Items></m:UpdateItemResponseMessage></m:ResponseMessages></m:UpdateItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:40:53 GMT
+  recorded_at: Mon, 09 May 2016 16:00:08 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/calendar_item/save.yml
+++ b/spec/cassettes/calendar_item/save.yml
@@ -40,14 +40,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - c5aaa209-0527-42b9-9c4d-689c4a66a84e
+      - 0a98aa17-9295-44f9-a4a0-bb9c4629afd7
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=c5453986db0f425b99a5cd9d00c7a504; expires=Sat, 06-May-2017
-        19:42:17 GMT; path=/; HttpOnly
+      - exchangecookie=ff7dcf5548f24c88a52f150567f150bb; expires=Sat, 06-May-2017
+        20:30:15 GMT; path=/; HttpOnly
       X-Ewshandler:
       - FindItem
       X-Aspnet-Version:
@@ -59,9 +59,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - BLUPR14CA0071
+      - CY1PR21CA0018
       Date:
-      - Fri, 06 May 2016 19:42:17 GMT
+      - Fri, 06 May 2016 20:30:15 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -71,14 +71,7 @@ http_interactions:
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:FindItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootFolder
-        TotalItemsInView="2" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjbAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABl4"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
-        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
-        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T18:40:30Z</t:DateTimeReceived><t:Size>3871</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T18:40:30Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T18:40:30Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T18:40:26Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T18:40:26Z</t:Start><t:End>2016-05-06T19:10:26Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>FIRST_NAME
-        FIRST_NAME LAST_NAME</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE
-        ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
-        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem><t:CalendarItem><t:ItemId
+        TotalItemsInView="1" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
         Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjaAAAA"
         ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABl2"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
         ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Appointment
@@ -88,7 +81,7 @@ http_interactions:
         ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC-06:00)
         Central Time (US &amp; Canada)</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>0</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 19:42:17 GMT
+  recorded_at: Fri, 06 May 2016 20:30:15 GMT
 - request:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
@@ -105,8 +98,10 @@ http_interactions:
               <Items>
                 <t:CalendarItem>
           <t:Subject>Calendar Item Subject</t:Subject>
-          <t:Start>2016-05-06T14:42:17-05:00</t:Start>
-          <t:End>2016-05-06T15:12:17-05:00</t:End>
+          <t:Body BodyType="Text">Body line 1.
+        Body line 2.</t:Body>
+          <t:Start>2016-05-06T15:30:15-05:00</t:Start>
+          <t:End>2016-05-06T16:00:15-05:00</t:End>
         </t:CalendarItem>
               </Items>
             </CreateItem>
@@ -133,14 +128,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 2fd90aef-12f9-4f3a-b9a2-91ef1f60f841
+      - 6c3b2fdd-4682-4f8c-9b56-e19eaa2e1914
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=c3a544ae3d8f425b934940045a0c192b; expires=Sat, 06-May-2017
-        19:42:18 GMT; path=/; HttpOnly
+      - exchangecookie=1a9feb93c2ea4add99dacc8d1ab9a70b; expires=Sat, 06-May-2017
+        20:30:16 GMT; path=/; HttpOnly
       X-Ewshandler:
       - CreateItem
       X-Aspnet-Version:
@@ -152,9 +147,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - DM3PR12CA0013
+      - BY1PR10CA0016
       Date:
-      - Fri, 06 May 2016 19:42:17 GMT
+      - Fri, 06 May 2016 20:30:16 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -164,10 +159,10 @@ http_interactions:
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:CreateItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjlAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmV"/></t:CalendarItem></m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse></s:Body></s:Envelope>
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjrAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmo"/></t:CalendarItem></m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 19:42:18 GMT
+  recorded_at: Fri, 06 May 2016 20:30:16 GMT
 - request:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
@@ -182,7 +177,7 @@ http_interactions:
                 <t:BaseShape>AllProperties</t:BaseShape>
               </ItemShape>
               <ItemIds>
-                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjlAAAA"/>
+                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjrAAAA"/>
               </ItemIds>
             </GetItem>
           </soap:Body>
@@ -208,14 +203,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - e16910f5-65ed-4363-a51a-c468aa19f987
+      - db63a11d-2aa3-4afd-9f6e-1aaab4c635b9
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=9eee39ad466c4a7e9c03db9ebf43b416; expires=Sat, 06-May-2017
-        19:42:19 GMT; path=/; HttpOnly
+      - exchangecookie=259ccaa2fbcd4234b2884d6b0caa951a; expires=Sat, 06-May-2017
+        20:30:16 GMT; path=/; HttpOnly
       X-Aspnet-Version:
       - 4.0.30319
       X-Diaginfo:
@@ -225,26 +220,16 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - DM3PR20CA0030
+      - BLUPR0601CA0027
       Date:
-      - Fri, 06 May 2016 19:42:19 GMT
+      - Fri, 06 May 2016 20:30:16 GMT
     body:
       encoding: UTF-8
-      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
-        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
-        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types"
-        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetItemResponse
-        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetItemResponseMessage
-        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjlAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmV"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
-        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
-        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:Body BodyType="Text"/><t:DateTimeReceived>2016-05-06T19:42:18Z</t:DateTimeReceived><t:Size>3823</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T19:42:18Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T19:42:18Z</t:DateTimeCreated><t:ResponseObjects><t:CancelCalendarItem/><t:ForwardItem/></t:ResponseObjects><t:ReminderDueBy>2016-05-06T19:42:17Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:DisplayCc/><t:DisplayTo/><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T19:42:17Z</t:Start><t:End>2016-05-06T20:12:17Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
-        SpecTester</t:Name><t:EmailAddress>FILTERED_EMAIL_ADDRESS</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
-        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse></s:Body></s:Envelope>
+      string: |-
+        <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjrAAAA" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmo"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA" ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:Body BodyType="Text">Body line 1.
+        Body line 2.</t:Body><t:DateTimeReceived>2016-05-06T20:30:16Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T20:30:16Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T20:30:16Z</t:DateTimeCreated><t:ResponseObjects><t:CancelCalendarItem/><t:ForwardItem/></t:ResponseObjects><t:ReminderDueBy>2016-05-06T20:30:15Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:DisplayCc/><t:DisplayTo/><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T20:30:15Z</t:Start><t:End>2016-05-06T21:00:15Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger SpecTester</t:Name><t:EmailAddress>FILTERED_EMAIL_ADDRESS</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC) Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 19:42:19 GMT
+  recorded_at: Fri, 06 May 2016 20:30:17 GMT
 - request:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
@@ -285,14 +270,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 9819ce35-f238-4818-9937-3812c0aeecfd
+      - 70b0b0c7-53b2-4818-af89-d6986829b6ee
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=75020fdb927c48a598e69d9d8cec33ce; expires=Sat, 06-May-2017
-        19:42:19 GMT; path=/; HttpOnly
+      - exchangecookie=ce980adb9d8b423e912602381b3207af; expires=Sat, 06-May-2017
+        20:30:17 GMT; path=/; HttpOnly
       X-Ewshandler:
       - FindItem
       X-Aspnet-Version:
@@ -304,9 +289,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - DM2PR10CA0054
+      - BY1PR19CA0005
       Date:
-      - Fri, 06 May 2016 19:42:20 GMT
+      - Fri, 06 May 2016 20:30:17 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -316,20 +301,13 @@ http_interactions:
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:FindItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootFolder
-        TotalItemsInView="3" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjlAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmV"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        TotalItemsInView="2" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjrAAAA"
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABmo"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
         ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
-        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T19:42:18Z</t:DateTimeReceived><t:Size>3823</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T19:42:18Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T19:42:18Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T19:42:17Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T19:42:17Z</t:Start><t:End>2016-05-06T20:12:17Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
+        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T20:30:16Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T20:30:16Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T20:30:16Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T20:30:15Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T20:30:15Z</t:Start><t:End>2016-05-06T21:00:15Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
         SpecTester</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE ADMINISTRATIVE
         GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
-        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjbAAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABl4"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
-        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
-        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-06T18:40:30Z</t:DateTimeReceived><t:Size>3871</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-06T18:40:30Z</t:DateTimeSent><t:DateTimeCreated>2016-05-06T18:40:30Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-06T18:40:26Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-06T18:40:26Z</t:Start><t:End>2016-05-06T19:10:26Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>FIRST_NAME
-        FIRST_NAME LAST_NAME</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE
-        ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
         Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem><t:CalendarItem><t:ItemId
         Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjaAAAA"
         ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABl2"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
@@ -340,5 +318,5 @@ http_interactions:
         ADMINISTRATIVE GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC-06:00)
         Central Time (US &amp; Canada)</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>0</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 19:42:20 GMT
+  recorded_at: Fri, 06 May 2016 20:30:17 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/calendar_item/save_cleanup.yml
+++ b/spec/cassettes/calendar_item/save_cleanup.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
     body:
       encoding: UTF-8
       string: |
@@ -11,7 +11,7 @@ http_interactions:
           <soap:Body>
             <DeleteItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" DeleteType="HardDelete" SendMeetingCancellations="SendToAllAndSaveCopy">
               <ItemIds>
-                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA"/>
+                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA"/>
               </ItemIds>
             </DeleteItem>
           </soap:Body>
@@ -37,14 +37,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - c0380b53-6470-4dbd-9acb-749ea56f190d
+      - 80fb0c16-e47d-494d-8539-1e3eb72a5e93
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=185f0d0b881c4598bb2133f24616127e; expires=Sat, 06-May-2017
-        20:40:53 GMT; path=/; HttpOnly
+      - exchangecookie=0e77f478e2ff4d39955012a1f1b0fd75; expires=Tue, 09-May-2017
+        16:00:08 GMT; path=/; HttpOnly
       X-Ewshandler:
       - DeleteItem
       X-Aspnet-Version:
@@ -56,9 +56,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - BY2PR08CA0069
+      - CO2PR07CA0006
       Date:
-      - Fri, 06 May 2016 20:40:53 GMT
+      - Mon, 09 May 2016 16:00:08 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -69,5 +69,5 @@ http_interactions:
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:DeleteItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode></m:DeleteItemResponseMessage></m:ResponseMessages></m:DeleteItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:40:53 GMT
+  recorded_at: Mon, 09 May 2016 16:00:08 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/calendar_item/save_cleanup.yml
+++ b/spec/cassettes/calendar_item/save_cleanup.yml
@@ -11,7 +11,7 @@ http_interactions:
           <soap:Body>
             <DeleteItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" DeleteType="HardDelete" SendMeetingCancellations="SendToAllAndSaveCopy">
               <ItemIds>
-                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjrAAAA"/>
+                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjuAAAA"/>
               </ItemIds>
             </DeleteItem>
           </soap:Body>
@@ -37,14 +37,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 31308d56-d910-45b0-9482-604f8989a0bd
+      - c0380b53-6470-4dbd-9acb-749ea56f190d
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=8b2b1075bf2b4c359e9d0312ba0b666c; expires=Sat, 06-May-2017
-        20:30:18 GMT; path=/; HttpOnly
+      - exchangecookie=185f0d0b881c4598bb2133f24616127e; expires=Sat, 06-May-2017
+        20:40:53 GMT; path=/; HttpOnly
       X-Ewshandler:
       - DeleteItem
       X-Aspnet-Version:
@@ -56,9 +56,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - CY1PR21CA0006
+      - BY2PR08CA0069
       Date:
-      - Fri, 06 May 2016 20:30:18 GMT
+      - Fri, 06 May 2016 20:40:53 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -69,5 +69,5 @@ http_interactions:
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:DeleteItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode></m:DeleteItemResponseMessage></m:ResponseMessages></m:DeleteItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 20:30:18 GMT
+  recorded_at: Fri, 06 May 2016 20:40:53 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/calendar_item/save_cleanup.yml
+++ b/spec/cassettes/calendar_item/save_cleanup.yml
@@ -11,7 +11,7 @@ http_interactions:
           <soap:Body>
             <DeleteItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" DeleteType="HardDelete" SendMeetingCancellations="SendToAllAndSaveCopy">
               <ItemIds>
-                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjlAAAA"/>
+                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjrAAAA"/>
               </ItemIds>
             </DeleteItem>
           </soap:Body>
@@ -37,14 +37,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - a868d4e7-be86-4157-bbda-936d483968bc
+      - 31308d56-d910-45b0-9482-604f8989a0bd
       X-Calculatedbetarget:
       - BY2PR08MB046.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=5dcaa1ccd1fa4b3ba8dd431e53e40d80; expires=Sat, 06-May-2017
-        19:42:20 GMT; path=/; HttpOnly
+      - exchangecookie=8b2b1075bf2b4c359e9d0312ba0b666c; expires=Sat, 06-May-2017
+        20:30:18 GMT; path=/; HttpOnly
       X-Ewshandler:
       - DeleteItem
       X-Aspnet-Version:
@@ -56,9 +56,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - DM2PR10CA0045
+      - CY1PR21CA0006
       Date:
-      - Fri, 06 May 2016 19:42:20 GMT
+      - Fri, 06 May 2016 20:30:18 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -69,5 +69,5 @@ http_interactions:
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:DeleteItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode></m:DeleteItemResponseMessage></m:ResponseMessages></m:DeleteItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Fri, 06 May 2016 19:42:21 GMT
+  recorded_at: Fri, 06 May 2016 20:30:18 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/calendar_item/save_cleanup.yml
+++ b/spec/cassettes/calendar_item/save_cleanup.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@outlook.office365.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body>
+            <DeleteItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" DeleteType="HardDelete" SendMeetingCancellations="SendToAllAndSaveCopy">
+              <ItemIds>
+                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhjlAAAA"/>
+              </ItemIds>
+            </DeleteItem>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/DeleteItem
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - a868d4e7-be86-4157-bbda-936d483968bc
+      X-Calculatedbetarget:
+      - BY2PR08MB046.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=5dcaa1ccd1fa4b3ba8dd431e53e40d80; expires=Sat, 06-May-2017
+        19:42:20 GMT; path=/; HttpOnly
+      X-Ewshandler:
+      - DeleteItem
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - BY2PR08MB046
+      X-Beserver:
+      - BY2PR08MB046
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - DM2PR10CA0045
+      Date:
+      - Fri, 06 May 2016 19:42:20 GMT
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:DeleteItemResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:DeleteItemResponseMessage
+        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode></m:DeleteItemResponseMessage></m:ResponseMessages></m:DeleteItemResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Fri, 06 May 2016 19:42:21 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/folder/find_calendar.yml
+++ b/spec/cassettes/folder/find_calendar.yml
@@ -4,20 +4,28 @@ http_interactions:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
     body:
-      encoding: US-ASCII
-      string: ! "<?xml version=\"1.0\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n
-        \ <soap:Body>\n    <GetFolder xmlns=\"http://schemas.microsoft.com/exchange/services/2006/messages\"
-        xmlns:t=\"http://schemas.microsoft.com/exchange/services/2006/types\">\n      <FolderShape>\n
-        \       <t:BaseShape>Default</t:BaseShape>\n      </FolderShape>\n      <FolderIds>\n
-        \       <t:DistinguishedFolderId Id=\"calendar\"/>\n      </FolderIds>\n    </GetFolder>\n
-        \ </soap:Body>\n</soap:Envelope>\n"
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Body>
+            <GetFolder xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+              <FolderShape>
+                <t:BaseShape>Default</t:BaseShape>
+              </FolderShape>
+              <FolderIds>
+                <t:DistinguishedFolderId Id="calendar"/>
+              </FolderIds>
+            </GetFolder>
+          </soap:Body>
+        </soap:Envelope>
     headers:
       Soapaction:
       - http://schemas.microsoft.com/exchange/services/2006/messages/GetFolder
       Content-Type:
       - text/xml; charset=utf-8
       Authorization:
-      - Basic ZWJlaWdhcnRzQGViZWlnYXJ0cy5vbm1pY3Jvc29mdC5jb206S3k1a2ltUDZTNmlIQQ==
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
   response:
     status:
       code: 200
@@ -30,31 +38,41 @@ http_interactions:
       Content-Type:
       - text/xml; charset=utf-8
       Server:
-      - Microsoft-IIS/7.5
-      Requestid:
-      - 56ded872-6c51-47fa-acfa-b3aa88c55c52
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - 561afca4-233e-4d3e-8d46-9c3b98f7bb42
+      X-Calculatedbetarget:
+      - BY2PR08MB046.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
       Set-Cookie:
-      - exchangecookie=a294c6d2503b4af2acab2ab6195297e4; expires=Fri, 11-Oct-2013
-        19:33:54 GMT; path=/; HttpOnly
+      - exchangecookie=7336c677cc004b11afaab1766f45de6c; expires=Tue, 09-May-2017
+        16:00:04 GMT; path=/; HttpOnly
+      X-Ewshandler:
+      - GetFolder
       X-Aspnet-Version:
-      - 2.0.50727
+      - 4.0.30319
+      X-Diaginfo:
+      - BY2PR08MB046
+      X-Beserver:
+      - BY2PR08MB046
       X-Powered-By:
       - ASP.NET
-      X-Diaginfo:
-      - AMSPRD0710CA014
+      X-Feserver:
+      - BY2PR13CA0012
       Date:
-      - Thu, 11 Oct 2012 19:33:54 GMT
+      - Mon, 09 May 2016 16:00:04 GMT
     body:
-      encoding: US-ASCII
+      encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
-        MajorVersion="14" MinorVersion="16" MajorBuildNumber="207" MinorBuildNumber="9"
-        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"/></s:Header><s:Body
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetFolderResponse
-        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetFolderResponseMessage
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:GetFolderResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetFolderResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Folders><t:CalendarFolder><t:FolderId
-        Id="AQAjAGViZWlnYXJ0c0BlYmVpZ2FydHMub25taWNyb3NvZnQuY29tAC4AAANQgkWQLjirSqRjoV/OICNYAQCaGrVTJjzWS7YVO+ElnoG4AAABRe2hAAAA"
-        ChangeKey="AgAAABYAAACaGrVTJjzWS7YVO+ElnoG4AAAARe3B"/><t:DisplayName>Calendar</t:DisplayName><t:ChildFolderCount>0</t:ChildFolderCount></t:CalendarFolder></m:Folders></m:GetFolderResponseMessage></m:ResponseMessages></m:GetFolderResponse></s:Body></s:Envelope>
+        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        ChangeKey="AgAAABYAAABO62zGwOguSJqyNahPUYshAAAAAAA3"/><t:DisplayName>Calendar</t:DisplayName><t:TotalCount>0</t:TotalCount><t:ChildFolderCount>2</t:ChildFolderCount></t:CalendarFolder></m:Folders></m:GetFolderResponseMessage></m:ResponseMessages></m:GetFolderResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Thu, 11 Oct 2012 19:33:54 GMT
-recorded_with: VCR 2.2.5
+  recorded_at: Mon, 09 May 2016 16:00:05 GMT
+recorded_with: VCR 3.0.1

--- a/spec/exchanger/calendar_item_spec.rb
+++ b/spec/exchanger/calendar_item_spec.rb
@@ -5,9 +5,32 @@ describe Exchanger::CalendarItem do
     @folder = VCR.use_cassette('folder/find_calendar') do
       Exchanger::Folder.find(:calendar)
     end
+    @calendar_item = @folder.new_calendar_item
   end
 
-  describe ".find" do
-    it "should find by id"
+  describe "#save" do
+    after do
+      if @calendar_item.persisted?
+        VCR.use_cassette("calendar_item/save_cleanup") do
+          @calendar_item.destroy
+        end
+      end
+    end
+
+    it "should create and update calendar item" do
+      VCR.use_cassette("calendar_item/save") do
+        prev_items_size = @folder.items.size
+        @calendar_item.subject = "Calendar Item Subject"
+        @calendar_item.start = Time.now
+        @calendar_item.end = Time.now + 30.minutes
+        @calendar_item.should be_changed
+        @calendar_item.save
+        @calendar_item.should_not be_new_record
+        @calendar_item.should_not be_changed
+        @calendar_item.reload
+        @calendar_item.subject.should == "Calendar Item Subject"
+        @folder.items.size.should == prev_items_size + 1
+      end
+    end
   end
 end

--- a/spec/exchanger/calendar_item_spec.rb
+++ b/spec/exchanger/calendar_item_spec.rb
@@ -31,6 +31,10 @@ describe Exchanger::CalendarItem do
         @calendar_item.reload
         @calendar_item.subject.should == "Calendar Item Subject"
         @folder.items.size.should == prev_items_size + 1
+        @calendar_item.subject = "Calendar Item Subject - Updated"
+        @calendar_item.should be_changed
+        @calendar_item.save
+        @calendar_item.should_not be_changed
       end
     end
   end

--- a/spec/exchanger/calendar_item_spec.rb
+++ b/spec/exchanger/calendar_item_spec.rb
@@ -21,6 +21,7 @@ describe Exchanger::CalendarItem do
       VCR.use_cassette("calendar_item/save") do
         prev_items_size = @folder.items.size
         @calendar_item.subject = "Calendar Item Subject"
+        @calendar_item.body = Exchanger::Body.new(text: "Body line 1.\nBody line 2.")
         @calendar_item.start = Time.now
         @calendar_item.end = Time.now + 30.minutes
         @calendar_item.should be_changed

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,6 @@ VCR.configure do |c|
   c.hook_into :webmock
   c.ignore_localhost = true
   c.default_cassette_options = { :record => :new_episodes }
-  c.filter_sensitive_data('FILTERED_USERNAME') { Exchanger.config.username.gsub("@", "%40") }
-  c.filter_sensitive_data('FILTERED_PASSWORD') { Exchanger.config.password }
+  c.filter_sensitive_data('FILTERED_USERNAME') { CGI::escape(Exchanger.config.username) }
+  c.filter_sensitive_data('FILTERED_PASSWORD') { CGI::escape(Exchanger.config.password) }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ VCR.configure do |c|
   c.hook_into :webmock
   c.ignore_localhost = true
   c.default_cassette_options = { :record => :new_episodes }
-  c.filter_sensitive_data('FILTERED_USERNAME') { CGI::escape(Exchanger.config.username) }
+  c.filter_sensitive_data('FILTERED_USERNAME') { CGI::escape(Exchanger.config.username) }  # Filter escaped version from request > uri
+  c.filter_sensitive_data('FILTERED_EMAIL_ADDRESS') { Exchanger.config.username }          # Filter unescaped version from request > body > string
   c.filter_sensitive_data('FILTERED_PASSWORD') { CGI::escape(Exchanger.config.password) }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,4 +22,10 @@ VCR.configure do |c|
   c.filter_sensitive_data('FILTERED_USERNAME') { CGI::escape(Exchanger.config.username) }  # Filter escaped version from request > uri
   c.filter_sensitive_data('FILTERED_EMAIL_ADDRESS') { Exchanger.config.username }          # Filter unescaped version from request > body > string
   c.filter_sensitive_data('FILTERED_PASSWORD') { CGI::escape(Exchanger.config.password) }
+
+  # Record an endpoint that matches the Travis CI configuration to ensure that the cassette files are used when CI tests run
+  ci_endpoint = YAML.load_file("#{File.dirname(__FILE__)}/config.yml.example")["endpoint"]
+  ci_endpoint = URI.parse(ci_endpoint).host
+  dev_endpoint = URI.parse(Exchanger.config.endpoint).host
+  c.filter_sensitive_data(ci_endpoint) { dev_endpoint }
 end


### PR DESCRIPTION
The CalendarView support in this gem has been very helpful!

This pull request addresses some issues I ran into with updating calendar items.  Please let me know if these would be OK to bring into master.

#### 1. VCR Version Bump
The VCR version was bumped up to 3.0.1 because version 2.2.5 was producing blank YAML files.

#### 2. VCR Password Filter Update
The VCR `filter_sensitive_data` use was updated to handle passwords with sensitive characters.  For example, a password of `secret!` would get encoded as `secret%21` and would remain in the cassette file.

#### 3. Contact Test Updates
When running the `contact_spec` on a fresh cassette, this failure occurred:

```
Exchanger::Operation::ResponseError:
The request failed schema validation: The 'SendMeetingInvitations' attribute is invalid - The value '' is invalid according to its datatype 'http://schemas.microsoft.com/exchange/services/2006/types:CalendarItemCreateOrDeleteOperationType' - The Enumeration constraint failed.
```

This appears to be because the `SendMeetingInvitations` attribute was added to the `CreateItem` operation for `CalendarItem#create` but this unintentionally affected `Item#create`.

#### 4. Return ID for New CalendarItem
A newly created Item would return its `id` but a CalendarItem would not.   CalendarItem needed to be able to use this code:

```ruby
response = UpdateItem.run(:items => [self])
move_changes
```

#### 5. Fix CalendarItem Destroy
Running `destroy` on a CalendarItem was resulting in:

```
Exchanger::Operation::ResponseError:
SendMeetingCancellations attribute is required for Calendar items.
```

I've added this attribute.

#### 6. Allow Body for New CalendarItem
When attempting to create a new calendar item with a `body` value, the request was failing on:

```
Exchanger::Operation::ResponseError:
The request failed schema validation: The required attribute 'BodyType' is missing.
```

I've created a new Body element to allow the `BodyType` to be sent.

#### 7. Fix CalendarItem Update
Running `save` on an existing CalendarItem was resulting in:

```
Exchanger::Operation::ResponseError:
The SendMeetingInvitationsOrCancellations attribute is required for calendar items.
```

I've added this attribute.

----
Note: The `calendar_item_spec.rb` is passing on my machine.  I'm not sure why it is failing in the Travis CI build.