### PR TITLE
Add File Attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Supported operations
 * FindFolder, GetFolder
 * ResolveNames, ExpandDL
 * GetUserAvailability
+* GetAttachment, CreateAttachment, DeleteAttachment
 
 Installing
 ==========

--- a/lib/exchanger.rb
+++ b/lib/exchanger.rb
@@ -42,6 +42,7 @@ require "exchanger/elements/contacts_folder"
 require "exchanger/elements/tasks_folder"
 require "exchanger/elements/search_folder"
 # Item elements
+require "exchanger/elements/attachment"
 require "exchanger/elements/item"
 require "exchanger/elements/message"
 require "exchanger/elements/calendar_item"
@@ -54,6 +55,8 @@ require "exchanger/elements/task"
 require "exchanger/elements/distribution_list"
 require "exchanger/elements/calendar_event_details"
 require "exchanger/elements/calendar_event"
+require "exchanger/elements/item_attachment"
+require "exchanger/elements/file_attachment"
 
 # Operations
 require "exchanger/operation"
@@ -67,6 +70,9 @@ require "exchanger/operations/delete_item"
 require "exchanger/operations/resolve_names"
 require "exchanger/operations/expand_dl"
 require "exchanger/operations/get_user_availability"
+require "exchanger/operations/get_attachment"
+require "exchanger/operations/create_attachment"
+require "exchanger/operations/delete_attachment"
 
 module Exchanger
   NS = {

--- a/lib/exchanger/attributes.rb
+++ b/lib/exchanger/attributes.rb
@@ -2,7 +2,7 @@ module Exchanger
   module Attributes
     def attributes=(values = {})
       values.each do |name, value|
-        write_attribute(name, value)
+        public_send("#{name}=", value)
       end
     end
 

--- a/lib/exchanger/element.rb
+++ b/lib/exchanger/element.rb
@@ -72,22 +72,25 @@ module Exchanger
     end
 
     def self.new_from_xml(xml)
-      object = new
+      new.assign_attributes_from_xml(xml)
+    end
+
+    def assign_attributes_from_xml(xml)
       # Keys
       xml.attributes.values.each do |attr|
         name = attr.name.underscore.to_sym
         value = attr.value
-        object.write_attribute(name, value)
+        write_attribute(name, value)
       end
       # Fields
       xml.children.each do |node|
         name = node.name.underscore.to_sym
         field = elements[name] || Field.new(name)
         value = field.value_from_xml(node)
-        object.write_attribute(name, value)
+        write_attribute(name, value)
       end
-      object.send(:reset_modifications)
-      object
+      send(:reset_modifications)
+      self
     end
 
     # Builds XML from elements and attributes

--- a/lib/exchanger/elements/attachment.rb
+++ b/lib/exchanger/elements/attachment.rb
@@ -1,0 +1,64 @@
+module Exchanger
+  class Attachment < Element
+    self.identifier_name = :attachment_id
+
+    element :attachment_id, type: Identifier
+    element :name
+    element :content_type
+    element :content_id
+    element :content_location
+    element :size, type: Integer
+    element :last_modified_time, type: Time
+    element :is_inline, type: Boolean
+
+    attr_accessor :parent_item_id
+
+    def self.find(id)
+      find_all([id]).first
+    end
+
+    def self.find_all(ids)
+      response = GetAttachment.run(attachment_ids: ids)
+      response.attachments
+    end
+
+    # The "Attachments" element contains the items or files that are attached to an item in the Exchange store.
+    #
+    #   <Attachments>
+    #     <ItemAttachment/>
+    #     <FileAttachment/>
+    #   </Attachments>
+    #
+    # https://msdn.microsoft.com/en-us/library/office/aa564869(v=exchg.150).aspx
+    #
+    # Determine if the given XML node contains an ItemAttachment or FileAttachment and initialize the new instance.
+    #
+    def self.new_from_xml(xml)
+      attachment_subclass = Exchanger.const_get(xml.name)
+      attachment_subclass.new.assign_attributes_from_xml(xml)
+    end
+
+    private
+
+      def create
+        if parent_item_id
+          response = CreateAttachment.run(parent_item_id: parent_item_id, attachments: [self])
+          self.attachment_id = response.attachment_ids[0]
+          move_changes
+          true
+        else
+          errors << "Parent item can't be blank"
+          false
+        end
+      end
+
+      def update
+        raise NotImplementedError, "There is no UpdateAttribute operation in Exchange.  Delete the attachment and recreate to update."
+      end
+
+      def delete
+        DeleteAttachment.run(attachment_ids: [id]) ? true : false
+      end
+
+  end
+end

--- a/lib/exchanger/elements/file_attachment.rb
+++ b/lib/exchanger/elements/file_attachment.rb
@@ -1,0 +1,17 @@
+module Exchanger
+  # The FileAttachment element represents a file that is attached to an item in the Exchange store.
+  #
+  # https://msdn.microsoft.com/en-us/library/office/aa580492(v=exchg.150).aspx
+  class FileAttachment < Attachment
+    element :is_contact_photo, type: Boolean
+    element :content
+
+    def content=(value)
+      write_attribute(:content, Base64.encode64(value))
+    end
+
+    def content
+      Base64.decode64(read_attribute(:content))
+    end
+  end
+end

--- a/lib/exchanger/elements/item.rb
+++ b/lib/exchanger/elements/item.rb
@@ -10,7 +10,7 @@ module Exchanger
     element :subject
     element :sensitivity
     element :body, type: Body
-    element :attachments, :type => [String]
+    element :attachments, :type => [Attachment]
     element :date_time_received, :type => Time
     element :size, :type => Integer
     element :categories, :type => [String]
@@ -66,6 +66,14 @@ module Exchanger
       @parent_folder ||= if parent_folder_id
         Folder.find(parent_folder_id.id)
       end
+    end
+
+    def new_file_attachment(attributes = {})
+      FileAttachment.new(attributes.merge(parent_item_id: item_id.id))
+    end
+
+    def file_attachments
+      attachments.select { |attachment| attachment.is_a?(FileAttachment) }
     end
 
     private

--- a/lib/exchanger/elements/item_attachment.rb
+++ b/lib/exchanger/elements/item_attachment.rb
@@ -1,0 +1,16 @@
+module Exchanger
+  # The ItemAttachment element represents an Exchange item that is attached to another Exchange item.
+  #
+  # https://msdn.microsoft.com/en-us/library/office/aa562997(v=exchg.150).aspx
+  class ItemAttachment < Attachment
+    element :item, type: Item
+    element :message, type: Message
+    element :calendar_item, type: CalendarItem
+    element :contact, type: Contact
+    element :task, type: Task
+    element :meeting_message, type: MeetingMessage
+    element :meeting_request, type: MeetingRequest
+    element :meeting_response, type: MeetingResponse
+    element :meeting_cancellation, type: MeetingCancellation
+  end
+end

--- a/lib/exchanger/operations/create_attachment.rb
+++ b/lib/exchanger/operations/create_attachment.rb
@@ -1,0 +1,44 @@
+module Exchanger
+  # The CreateAttachment element defines a request to create an attachment to an item in the Exchange store.
+  #
+  # https://msdn.microsoft.com/en-us/library/office/aa565931(v=exchg.150).aspx
+  class CreateAttachment < Operation
+    class Request < Operation::Request
+      attr_accessor :parent_item_id, :attachments
+
+      # Reset request options to defaults.
+      def reset
+        @parent_item_id = nil
+        @attachments = []
+      end
+
+      def to_xml
+        Nokogiri::XML::Builder.new do |xml|
+          xml.send("soap:Envelope", "xmlns:soap" => NS["soap"], "xmlns:t" => NS["t"], "xmlns:xsi" => NS["xsi"], "xmlns:xsd" => NS["xsd"]) do
+            xml.send("soap:Body") do
+              xml.CreateAttachment("xmlns" => NS["m"]) do
+                xml.ParentItemId("Id" => parent_item_id)
+                xml.Attachments do
+                  attachments.each do |attachment|
+                    attachment_xml = attachment.to_xml
+                    attachment_xml.add_namespace_definition("t", NS["t"])
+                    attachment_xml.namespace = attachment_xml.namespace_definitions[0]
+                    xml << attachment_xml.to_s
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    class Response < Operation::Response
+      def attachment_ids
+        to_xml.xpath(".//t:AttachmentId", NS).map do |node|
+          Identifier.new_from_xml(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/exchanger/operations/delete_attachment.rb
+++ b/lib/exchanger/operations/delete_attachment.rb
@@ -1,0 +1,34 @@
+module Exchanger
+  # The DeleteAttachment element is the root element in a request to delete an attachment from the Exchange store.
+  #
+  # https://msdn.microsoft.com/en-us/library/office/aa580612(v=exchg.150).aspx
+  class DeleteAttachment < Operation
+    class Request < Operation::Request
+      attr_accessor :attachment_ids
+
+      # Reset request options to defaults.
+      def reset
+        @attachment_ids = []
+      end
+
+      def to_xml
+        Nokogiri::XML::Builder.new do |xml|
+          xml.send("soap:Envelope", "xmlns:soap" => NS["soap"], "xmlns:t" => NS["t"], "xmlns:xsi" => NS["xsi"], "xmlns:xsd" => NS["xsd"]) do
+            xml.send("soap:Body") do
+              xml.DeleteAttachment("xmlns" => NS["m"]) do
+                xml.AttachmentIds do
+                  attachment_ids.each do |attachment_id|
+                    xml["t"].AttachmentId("Id" => attachment_id)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    class Response < Operation::Response
+    end
+  end
+end

--- a/lib/exchanger/operations/get_attachment.rb
+++ b/lib/exchanger/operations/get_attachment.rb
@@ -1,0 +1,44 @@
+module Exchanger
+  # The GetAttachment element is the root element in a request to get an attachment from the Exchange store.
+  #
+  # https://msdn.microsoft.com/en-us/library/office/aa564204(v=exchg.150).aspx
+  class GetAttachment < Operation
+    class Request < Operation::Request
+      attr_accessor :attachment_ids, :base_shape
+
+      # Reset request options to defaults.
+      def reset
+        @attachment_ids = []
+        @base_shape = :all_properties
+      end
+
+      def to_xml
+        Nokogiri::XML::Builder.new do |xml|
+          xml.send("soap:Envelope", "xmlns:soap" => NS["soap"]) do
+            xml.send("soap:Body") do
+              xml.GetAttachment("xmlns" => NS["m"], "xmlns:t" => NS["t"]) do
+                xml.AttachmentShape do
+                  xml.send "t:BaseShape", base_shape.to_s.camelize
+                end
+                xml.AttachmentIds do
+                  attachment_ids.each do |attachment_id|
+                    xml.send("t:AttachmentId", "Id" => attachment_id)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    class Response < Operation::Response
+      def attachments
+        to_xml.xpath(".//m:Attachments", NS).children.map do |node|
+          attachment_klass = Exchanger.const_get(node.name)
+          attachment_klass.new_from_xml(node)
+        end
+      end
+    end
+  end
+end

--- a/spec/cassettes/calendar_item/save.yml
+++ b/spec/cassettes/calendar_item/save.yml
@@ -40,40 +40,46 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 78b66928-80a4-48f0-8ccd-403018a99bae
+      - b4a9ca09-b95b-42cb-9120-ac55df73a696
       X-Calculatedbetarget:
-      - BY2PR08MB046.namprd08.prod.outlook.com
+      - CO2PR0801MB552.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=484d62f46101483db34928b7525f50e6; expires=Tue, 09-May-2017
-        16:00:05 GMT; path=/; HttpOnly
+      - exchangecookie=1220f01c67eb4194b30c77e969ce3d1d; expires=Wed, 21-Jun-2017
+        14:13:10 GMT; path=/; HttpOnly
       X-Ewshandler:
       - FindItem
       X-Aspnet-Version:
       - 4.0.30319
       X-Diaginfo:
-      - BY2PR08MB046
+      - CO2PR0801MB552
       X-Beserver:
-      - BY2PR08MB046
+      - CO2PR0801MB552
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - BY2PR16CA0015
+      - BY2PR06CA0074
       Date:
-      - Mon, 09 May 2016 16:00:04 GMT
+      - Tue, 21 Jun 2016 14:13:09 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
-        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="523" MinorBuildNumber="16"
         xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:FindItemResponse
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:FindItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootFolder
-        TotalItemsInView="0" IncludesLastItemInRange="true"><t:Items/></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
+        TotalItemsInView="1" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
+        Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGiCAAA="
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJiya"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>New...</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-06-20T13:43:18Z</t:DateTimeReceived><t:Size>17941</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-06-20T13:43:18Z</t:DateTimeSent><t:DateTimeCreated>2016-06-20T13:43:18Z</t:DateTimeCreated><t:ReminderDueBy>2016-06-20T05:00:00Z</t:ReminderDueBy><t:ReminderIsSet>false</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>true</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-06-20T05:00:00Z</t:Start><t:End>2016-06-21T05:00:00Z</t:End><t:IsAllDayEvent>true</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Free</t:LegacyFreeBusyStatus><t:Location/><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
+        SpecTester</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE ADMINISTRATIVE
+        GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>P1D</t:Duration><t:TimeZone>(UTC-06:00)
+        Central Time (US &amp; Canada)</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Mon, 09 May 2016 16:00:05 GMT
+  recorded_at: Tue, 21 Jun 2016 14:13:10 GMT
 - request:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
@@ -89,11 +95,11 @@ http_interactions:
               </SavedItemFolderId>
               <Items>
                 <t:CalendarItem>
-          <t:Subject>Calendar Item Subject</t:Subject>
+          <t:Subject>Test Calendar Item</t:Subject>
           <t:Body BodyType="Text">Body line 1.
         Body line 2.</t:Body>
-          <t:Start>2016-05-09T11:00:05-05:00</t:Start>
-          <t:End>2016-05-09T11:30:05-05:00</t:End>
+          <t:Start>2016-06-21T09:13:09-05:00</t:Start>
+          <t:End>2016-06-21T09:43:09-05:00</t:End>
         </t:CalendarItem>
               </Items>
             </CreateItem>
@@ -120,41 +126,41 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 89c8e07e-05f2-4e45-902d-277f996d26ee
+      - 99313b13-0e00-453b-8f03-c84dbdebf397
       X-Calculatedbetarget:
-      - BY2PR08MB046.namprd08.prod.outlook.com
+      - CO2PR0801MB552.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=00047aa713014d7eb7c0e8409ce35415; expires=Tue, 09-May-2017
-        16:00:06 GMT; path=/; HttpOnly
+      - exchangecookie=8fac18a39ac84561952a4ef40aee59e4; expires=Wed, 21-Jun-2017
+        14:13:11 GMT; path=/; HttpOnly
       X-Ewshandler:
       - CreateItem
       X-Aspnet-Version:
       - 4.0.30319
       X-Diaginfo:
-      - BY2PR08MB046
+      - CO2PR0801MB552
       X-Beserver:
-      - BY2PR08MB046
+      - CO2PR0801MB552
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - CO2PR07CA0003
+      - BLUPR0601CA0002
       Date:
-      - Mon, 09 May 2016 16:00:05 GMT
+      - Tue, 21 Jun 2016 14:13:10 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
-        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="523" MinorBuildNumber="16"
         xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:CreateItemResponse
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:CreateItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABnp"/></t:CalendarItem></m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse></s:Body></s:Envelope>
+        Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi8AAA="
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJizZ"/></t:CalendarItem></m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Mon, 09 May 2016 16:00:06 GMT
+  recorded_at: Tue, 21 Jun 2016 14:13:11 GMT
 - request:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
@@ -169,7 +175,7 @@ http_interactions:
                 <t:BaseShape>AllProperties</t:BaseShape>
               </ItemShape>
               <ItemIds>
-                <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA"/>
+                <t:ItemId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi8AAA="/>
               </ItemIds>
             </GetItem>
           </soap:Body>
@@ -195,33 +201,33 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 996d9cc2-cd10-4358-b933-e9d745d9dbf8
+      - 3891b2fb-892d-40e5-8bc2-2e2b12af528e
       X-Calculatedbetarget:
-      - BY2PR08MB046.namprd08.prod.outlook.com
+      - CO2PR0801MB552.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=de130f3131f94c48a0ed6b538f3fa209; expires=Tue, 09-May-2017
-        16:00:06 GMT; path=/; HttpOnly
+      - exchangecookie=3858546dae864d05ba89385bbc3f9f56; expires=Wed, 21-Jun-2017
+        14:13:12 GMT; path=/; HttpOnly
       X-Aspnet-Version:
       - 4.0.30319
       X-Diaginfo:
-      - BY2PR08MB046
+      - CO2PR0801MB552
       X-Beserver:
-      - BY2PR08MB046
+      - CO2PR0801MB552
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - CO2PR07CA0006
+      - BY2PR13CA0031
       Date:
-      - Mon, 09 May 2016 16:00:06 GMT
+      - Tue, 21 Jun 2016 14:13:11 GMT
     body:
       encoding: UTF-8
       string: |-
-        <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABnp"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA" ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:Body BodyType="Text">Body line 1.
-        Body line 2.</t:Body><t:DateTimeReceived>2016-05-09T16:00:06Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-09T16:00:06Z</t:DateTimeSent><t:DateTimeCreated>2016-05-09T16:00:06Z</t:DateTimeCreated><t:ResponseObjects><t:CancelCalendarItem/><t:ForwardItem/></t:ResponseObjects><t:ReminderDueBy>2016-05-09T16:00:05Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:DisplayCc/><t:DisplayTo/><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-09T16:00:05Z</t:Start><t:End>2016-05-09T16:30:05Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger SpecTester</t:Name><t:EmailAddress>FILTERED_EMAIL_ADDRESS</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC) Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse></s:Body></s:Envelope>
+        <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo MajorVersion="15" MinorVersion="1" MajorBuildNumber="523" MinorBuildNumber="16" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi8AAA=" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJizZ"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA" ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Test Calendar Item</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:Body BodyType="Text">Body line 1.
+        Body line 2.</t:Body><t:DateTimeReceived>2016-06-21T14:13:11Z</t:DateTimeReceived><t:Size>3939</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-06-21T14:13:11Z</t:DateTimeSent><t:DateTimeCreated>2016-06-21T14:13:11Z</t:DateTimeCreated><t:ResponseObjects><t:CancelCalendarItem/><t:ForwardItem/></t:ResponseObjects><t:ReminderDueBy>2016-06-21T14:13:09Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:DisplayCc/><t:DisplayTo/><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-06-21T14:13:09Z</t:Start><t:End>2016-06-21T14:43:09Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger SpecTester</t:Name><t:EmailAddress>FILTERED_EMAIL_ADDRESS</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC) Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Mon, 09 May 2016 16:00:06 GMT
+  recorded_at: Tue, 21 Jun 2016 14:13:11 GMT
 - request:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
@@ -262,47 +268,53 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - f61fc06d-7c71-474d-ad95-48c1007a4730
+      - 754e4356-536d-4a8b-af8d-c232f2512294
       X-Calculatedbetarget:
-      - BY2PR08MB046.namprd08.prod.outlook.com
+      - CO2PR0801MB552.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=dcc2b32cb962435c9ab071e44abf18a1; expires=Tue, 09-May-2017
-        16:00:07 GMT; path=/; HttpOnly
+      - exchangecookie=9ffc5a9a5cea488d9d9a2b0f56ac5118; expires=Wed, 21-Jun-2017
+        14:13:12 GMT; path=/; HttpOnly
       X-Ewshandler:
       - FindItem
       X-Aspnet-Version:
       - 4.0.30319
       X-Diaginfo:
-      - BY2PR08MB046
+      - CO2PR0801MB552
       X-Beserver:
-      - BY2PR08MB046
+      - CO2PR0801MB552
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - BY2PR13CA0003
+      - YTXPR01CA0068
       Date:
-      - Mon, 09 May 2016 16:00:07 GMT
+      - Tue, 21 Jun 2016 14:13:12 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
-        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="523" MinorBuildNumber="16"
         xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:FindItemResponse
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:FindItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootFolder
-        TotalItemsInView="1" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABnp"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
-        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Calendar
-        Item Subject</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-05-09T16:00:06Z</t:DateTimeReceived><t:Size>3925</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-05-09T16:00:06Z</t:DateTimeSent><t:DateTimeCreated>2016-05-09T16:00:06Z</t:DateTimeCreated><t:ReminderDueBy>2016-05-09T16:00:05Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-05-09T16:00:05Z</t:Start><t:End>2016-05-09T16:30:05Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
+        TotalItemsInView="2" IncludesLastItemInRange="true"><t:Items><t:CalendarItem><t:ItemId
+        Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi8AAA="
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJizZ"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Test
+        Calendar Item</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-06-21T14:13:11Z</t:DateTimeReceived><t:Size>3939</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-06-21T14:13:11Z</t:DateTimeSent><t:DateTimeCreated>2016-06-21T14:13:11Z</t:DateTimeCreated><t:ReminderDueBy>2016-06-21T14:13:09Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>false</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-06-21T14:13:09Z</t:Start><t:End>2016-06-21T14:43:09Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
         SpecTester</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE ADMINISTRATIVE
         GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC)
-        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
+        Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem><t:CalendarItem><t:ItemId
+        Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGiCAAA="
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJiya"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"
+        ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>New...</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:DateTimeReceived>2016-06-20T13:43:18Z</t:DateTimeReceived><t:Size>17941</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-06-20T13:43:18Z</t:DateTimeSent><t:DateTimeCreated>2016-06-20T13:43:18Z</t:DateTimeCreated><t:ReminderDueBy>2016-06-20T05:00:00Z</t:ReminderDueBy><t:ReminderIsSet>false</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:HasAttachments>true</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-06-20T05:00:00Z</t:Start><t:End>2016-06-21T05:00:00Z</t:End><t:IsAllDayEvent>true</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Free</t:LegacyFreeBusyStatus><t:Location/><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger
+        SpecTester</t:Name><t:EmailAddress>/O=FIRST ORGANIZATION/OU=EXCHANGE ADMINISTRATIVE
+        GROUP(FYDIBOHF23SPDLT)/CN=RECIPIENTS/CN=0003BFFDF431A754</t:EmailAddress><t:RoutingType>EX</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>P1D</t:Duration><t:TimeZone>(UTC-06:00)
+        Central Time (US &amp; Canada)</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></t:Items></m:RootFolder></m:FindItemResponseMessage></m:ResponseMessages></m:FindItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Mon, 09 May 2016 16:00:07 GMT
+  recorded_at: Tue, 21 Jun 2016 14:13:12 GMT
 - request:
     method: post
     uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
@@ -315,12 +327,12 @@ http_interactions:
             <UpdateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" ConflictResolution="AlwaysOverwrite" SendMeetingInvitationsOrCancellations="SendToAllAndSaveCopy">
               <ItemChanges>
                 <t:ItemChange>
-          <t:ItemId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABnp"/>
+          <t:ItemId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi8AAA=" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJizZ"/>
           <t:Updates>
             <t:SetItemField>
               <t:FieldURI FieldURI="item:Subject"/>
               <t:CalendarItem>
-                <t:Subject>Calendar Item Subject - Updated</t:Subject>
+                <t:Subject>Test Calendar Item Updated</t:Subject>
               </t:CalendarItem>
             </t:SetItemField>
           </t:Updates>
@@ -350,39 +362,39 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - 8bf1efd8-64fc-41fc-9eb8-931141846e64
+      - e57a3b2b-c412-49b4-b1a1-643a104d9d86
       X-Calculatedbetarget:
-      - BY2PR08MB046.namprd08.prod.outlook.com
+      - CO2PR0801MB552.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=d1acd3cb14304f67b34e27caa30c26ca; expires=Tue, 09-May-2017
-        16:00:07 GMT; path=/; HttpOnly
+      - exchangecookie=1a78a99170d34409a9c678faeb165950; expires=Wed, 21-Jun-2017
+        14:13:13 GMT; path=/; HttpOnly
       X-Ewshandler:
       - UpdateItem
       X-Aspnet-Version:
       - 4.0.30319
       X-Diaginfo:
-      - BY2PR08MB046
+      - CO2PR0801MB552
       X-Beserver:
-      - BY2PR08MB046
+      - CO2PR0801MB552
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - CY1PR21CA0005
+      - BY2PR16CA0014
       Date:
-      - Mon, 09 May 2016 16:00:07 GMT
+      - Tue, 21 Jun 2016 14:13:12 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
-        MajorVersion="15" MinorVersion="1" MajorBuildNumber="492" MinorBuildNumber="11"
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="523" MinorBuildNumber="16"
         xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:UpdateItemResponse
         xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:UpdateItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
-        Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ARgAABKlVK7wi0Um5a7NdGSAWsQcATutsxsDoLkiasjWoT1GLIQAAAgENAAAATutsxsDoLkiasjWoT1GLIQAAAhj5AAAA"
-        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAAABnr"/></t:CalendarItem></m:Items></m:UpdateItemResponseMessage></m:ResponseMessages></m:UpdateItemResponse></s:Body></s:Envelope>
+        Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi8AAA="
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJizb"/></t:CalendarItem></m:Items></m:UpdateItemResponseMessage></m:ResponseMessages></m:UpdateItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Mon, 09 May 2016 16:00:08 GMT
+  recorded_at: Tue, 21 Jun 2016 14:13:13 GMT
 recorded_with: VCR 3.0.1

--- a/spec/cassettes/calendar_item/save_file_attachment.yml
+++ b/spec/cassettes/calendar_item/save_file_attachment.yml
@@ -1,0 +1,374 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body>
+            <CreateItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" SendMeetingInvitations="SendToAllAndSaveCopy">
+              <SavedItemFolderId>
+                <t:FolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA"/>
+              </SavedItemFolderId>
+              <Items>
+                <t:CalendarItem>
+          <t:Subject>Test Calendar Item</t:Subject>
+          <t:Body BodyType="Text">Body line 1.
+        Body line 2.</t:Body>
+          <t:Start>2016-06-21T09:13:14-05:00</t:Start>
+          <t:End>2016-06-21T09:43:14-05:00</t:End>
+        </t:CalendarItem>
+              </Items>
+            </CreateItem>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/CreateItem
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - 9d7369a5-0482-43b4-be6a-78f400a31b21
+      X-Calculatedbetarget:
+      - CO2PR0801MB552.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=a0afd69d84e544feafcbccf6d81cf3b1; expires=Wed, 21-Jun-2017
+        14:13:15 GMT; path=/; HttpOnly
+      X-Ewshandler:
+      - CreateItem
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - CO2PR0801MB552
+      X-Beserver:
+      - CO2PR0801MB552
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - BY1PR19CA0019
+      Date:
+      - Tue, 21 Jun 2016 14:13:13 GMT
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="523" MinorBuildNumber="16"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:CreateItemResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:CreateItemResponseMessage
+        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId
+        Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAA="
+        ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJize"/></t:CalendarItem></m:Items></m:CreateItemResponseMessage></m:ResponseMessages></m:CreateItemResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Tue, 21 Jun 2016 14:13:14 GMT
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body>
+            <CreateAttachment xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <ParentItemId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAA="/>
+              <Attachments>
+                <t:FileAttachment>
+          <t:Name>test.txt</t:Name>
+          <t:ContentType>text/plain</t:ContentType>
+          <t:Content>VGVzdCBDb250ZW50
+        </t:Content>
+        </t:FileAttachment>
+              </Attachments>
+            </CreateAttachment>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/CreateAttachment
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - e3859936-4b38-49cf-8b68-c1de0a8030aa
+      X-Calculatedbetarget:
+      - CO2PR0801MB552.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=e494592941624251b0e089f04d054993; expires=Wed, 21-Jun-2017
+        14:13:15 GMT; path=/; HttpOnly
+      X-Ewshandler:
+      - CreateAttachment
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - CO2PR0801MB552
+      X-Beserver:
+      - CO2PR0801MB552
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - BY1PR10CA0031
+      Date:
+      - Tue, 21 Jun 2016 14:13:14 GMT
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="523" MinorBuildNumber="16"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:CreateAttachmentResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:CreateAttachmentResponseMessage
+        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Attachments><t:FileAttachment><t:AttachmentId
+        Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAABEgAQAD3x18GLNmVLgCkwN+NmLSk="
+        RootItemId="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAA="
+        RootItemChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJizf"/><t:LastModifiedTime>2016-06-21T14:13:15</t:LastModifiedTime></t:FileAttachment></m:Attachments></m:CreateAttachmentResponseMessage></m:ResponseMessages></m:CreateAttachmentResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Tue, 21 Jun 2016 14:13:15 GMT
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Body>
+            <GetItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+              <ItemShape>
+                <t:BaseShape>AllProperties</t:BaseShape>
+              </ItemShape>
+              <ItemIds>
+                <t:ItemId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAA="/>
+              </ItemIds>
+            </GetItem>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/GetItem
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - fd6f7300-940d-41c5-bedc-dfe56c9939d9
+      X-Calculatedbetarget:
+      - CO2PR0801MB552.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=0297fe2cb6344f15a2ecc65eb0a989fb; expires=Wed, 21-Jun-2017
+        14:13:26 GMT; path=/; HttpOnly
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - CO2PR0801MB552
+      X-Beserver:
+      - CO2PR0801MB552
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - BY1PR19CA0008
+      Date:
+      - Tue, 21 Jun 2016 14:13:25 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo MajorVersion="15" MinorVersion="1" MajorBuildNumber="523" MinorBuildNumber="16" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetItemResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetItemResponseMessage ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Items><t:CalendarItem><t:ItemId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAA=" ChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJizf"/><t:ParentFolderId Id="AQAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb28Aay5jb20ALgAABKlVK7wi0Um5a7NdGSAWsQEATutsxsDoLkiasjWoT1GLIQAAAgENAAAA" ChangeKey="AQAAAA=="/><t:ItemClass>IPM.Appointment</t:ItemClass><t:Subject>Test Calendar Item</t:Subject><t:Sensitivity>Normal</t:Sensitivity><t:Body BodyType="Text">Body line 1.
+        Body line 2.</t:Body><t:Attachments><t:FileAttachment><t:AttachmentId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAABEgAQAD3x18GLNmVLgCkwN+NmLSk="/><t:Name>test.txt</t:Name><t:ContentType>text/plain</t:ContentType></t:FileAttachment></t:Attachments><t:DateTimeReceived>2016-06-21T14:13:15Z</t:DateTimeReceived><t:Size>4166</t:Size><t:Importance>Normal</t:Importance><t:IsSubmitted>false</t:IsSubmitted><t:IsDraft>false</t:IsDraft><t:IsFromMe>false</t:IsFromMe><t:IsResend>false</t:IsResend><t:IsUnmodified>false</t:IsUnmodified><t:DateTimeSent>2016-06-21T14:13:15Z</t:DateTimeSent><t:DateTimeCreated>2016-06-21T14:13:15Z</t:DateTimeCreated><t:ResponseObjects><t:CancelCalendarItem/><t:ForwardItem/></t:ResponseObjects><t:ReminderDueBy>2016-06-21T14:13:14Z</t:ReminderDueBy><t:ReminderIsSet>true</t:ReminderIsSet><t:ReminderMinutesBeforeStart>15</t:ReminderMinutesBeforeStart><t:DisplayCc/><t:DisplayTo/><t:HasAttachments>true</t:HasAttachments><t:Culture>en-US</t:Culture><t:Start>2016-06-21T14:13:14Z</t:Start><t:End>2016-06-21T14:43:14Z</t:End><t:IsAllDayEvent>false</t:IsAllDayEvent><t:LegacyFreeBusyStatus>Busy</t:LegacyFreeBusyStatus><t:IsMeeting>true</t:IsMeeting><t:IsCancelled>false</t:IsCancelled><t:IsRecurring>false</t:IsRecurring><t:MeetingRequestWasSent>false</t:MeetingRequestWasSent><t:IsResponseRequested>true</t:IsResponseRequested><t:CalendarItemType>Single</t:CalendarItemType><t:MyResponseType>Organizer</t:MyResponseType><t:Organizer><t:Mailbox><t:Name>Exchanger SpecTester</t:Name><t:EmailAddress>FILTERED_EMAIL_ADDRESS</t:EmailAddress><t:RoutingType>SMTP</t:RoutingType></t:Mailbox></t:Organizer><t:Duration>PT30M</t:Duration><t:TimeZone>(UTC) Monrovia, Reykjavik</t:TimeZone><t:AppointmentSequenceNumber>0</t:AppointmentSequenceNumber><t:AppointmentState>1</t:AppointmentState><t:IsOnlineMeeting>false</t:IsOnlineMeeting></t:CalendarItem></m:Items></m:GetItemResponseMessage></m:ResponseMessages></m:GetItemResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Tue, 21 Jun 2016 14:13:26 GMT
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Body>
+            <GetAttachment xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+              <AttachmentShape>
+                <t:BaseShape>AllProperties</t:BaseShape>
+              </AttachmentShape>
+              <AttachmentIds>
+                <t:AttachmentId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAABEgAQAD3x18GLNmVLgCkwN+NmLSk="/>
+              </AttachmentIds>
+            </GetAttachment>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/GetAttachment
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - 57e66672-a146-42f9-9a84-9891ee8d4b6d
+      X-Calculatedbetarget:
+      - CO2PR0801MB552.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=cd0159d4f952418e9e0cd7a2c1edf614; expires=Wed, 21-Jun-2017
+        14:13:27 GMT; path=/; HttpOnly
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - CO2PR0801MB552
+      X-Beserver:
+      - CO2PR0801MB552
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - BY1PR19CA0018
+      Date:
+      - Tue, 21 Jun 2016 14:13:26 GMT
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="523" MinorBuildNumber="16"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"><m:GetAttachmentResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:GetAttachmentResponseMessage
+        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:Attachments><t:FileAttachment><t:AttachmentId
+        Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAABEgAQAD3x18GLNmVLgCkwN+NmLSk="/><t:Name>test.txt</t:Name><t:ContentType>text/plain</t:ContentType><t:Content>VGVzdCBDb250ZW50</t:Content></t:FileAttachment></m:Attachments></m:GetAttachmentResponseMessage></m:ResponseMessages></m:GetAttachmentResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Tue, 21 Jun 2016 14:13:26 GMT
+- request:
+    method: post
+    uri: https://FILTERED_USERNAME:FILTERED_PASSWORD@amsprd0710.outlook.com/EWS/Exchange.asmx
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0"?>
+        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body>
+            <DeleteAttachment xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+              <AttachmentIds>
+                <t:AttachmentId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAABEgAQAD3x18GLNmVLgCkwN+NmLSk="/>
+              </AttachmentIds>
+            </DeleteAttachment>
+          </soap:Body>
+        </soap:Envelope>
+    headers:
+      Soapaction:
+      - http://schemas.microsoft.com/exchange/services/2006/messages/DeleteAttachment
+      Content-Type:
+      - text/xml; charset=utf-8
+      Authorization:
+      - Basic Y2hhZF9leGNoYW5nZXJ0ZXN0aW5nQG91dGxvb2suY29tOmV4Y2hhbmdlcl9zcGVjMzMzIQ==
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - text/xml; charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      Request-Id:
+      - 0c5e6934-8122-4ffd-9439-75c3df3700d4
+      X-Calculatedbetarget:
+      - CO2PR0801MB552.namprd08.prod.outlook.com
+      X-Backendhttpstatus:
+      - '200'
+      Set-Cookie:
+      - exchangecookie=6c63f412ce7048b4b96755b17043c82c; expires=Wed, 21-Jun-2017
+        14:13:27 GMT; path=/; HttpOnly
+      X-Ewshandler:
+      - DeleteAttachment
+      X-Aspnet-Version:
+      - 4.0.30319
+      X-Diaginfo:
+      - CO2PR0801MB552
+      X-Beserver:
+      - CO2PR0801MB552
+      X-Powered-By:
+      - ASP.NET
+      X-Feserver:
+      - CY1PR21CA0023
+      Date:
+      - Tue, 21 Jun 2016 14:13:27 GMT
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
+        MajorVersion="15" MinorVersion="1" MajorBuildNumber="523" MinorBuildNumber="16"
+        xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/></s:Header><s:Body><m:DeleteAttachmentResponse
+        xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:DeleteAttachmentResponseMessage
+        ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode><m:RootItemId
+        RootItemId="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAA="
+        RootItemChangeKey="DwAAABYAAABO62zGwOguSJqyNahPUYshAAAcJizg"/></m:DeleteAttachmentResponseMessage></m:ResponseMessages></m:DeleteAttachmentResponse></s:Body></s:Envelope>
+    http_version: 
+  recorded_at: Tue, 21 Jun 2016 14:13:27 GMT
+recorded_with: VCR 3.0.1

--- a/spec/cassettes/calendar_item/save_file_attachment_cleanup.yml
+++ b/spec/cassettes/calendar_item/save_file_attachment_cleanup.yml
@@ -11,7 +11,7 @@ http_interactions:
           <soap:Body>
             <DeleteItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" DeleteType="HardDelete" SendMeetingCancellations="SendToAllAndSaveCopy">
               <ItemIds>
-                <t:ItemId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi8AAA="/>
+                <t:ItemId Id="AAAhAGNoYWRfZXhjaGFuZ2VydGVzdGluZ0BvdXRsb29rLmNvbQBGAAAAAAAAqVUrvCLRSblrs10ZIBaxBwBO62zGwOguSJqyNahPUYshAAAAAAENAABO62zGwOguSJqyNahPUYshAAAcJGi9AAA="/>
               </ItemIds>
             </DeleteItem>
           </soap:Body>
@@ -37,14 +37,14 @@ http_interactions:
       Server:
       - Microsoft-IIS/8.0
       Request-Id:
-      - c9f0900b-b14e-4b4b-8a1b-f65ac64a7244
+      - 3ef1eef1-ee8b-4a62-b05e-85a2c72ad1e0
       X-Calculatedbetarget:
       - CO2PR0801MB552.namprd08.prod.outlook.com
       X-Backendhttpstatus:
       - '200'
       Set-Cookie:
-      - exchangecookie=9201d47cd2174b3d9e1af9464175b397; expires=Wed, 21-Jun-2017
-        14:13:14 GMT; path=/; HttpOnly
+      - exchangecookie=aa4862a055bf420b8708234ff32c168c; expires=Wed, 21-Jun-2017
+        14:13:28 GMT; path=/; HttpOnly
       X-Ewshandler:
       - DeleteItem
       X-Aspnet-Version:
@@ -56,9 +56,9 @@ http_interactions:
       X-Powered-By:
       - ASP.NET
       X-Feserver:
-      - CO2PR20CA0007
+      - BY1PR10CA0002
       Date:
-      - Tue, 21 Jun 2016 14:13:13 GMT
+      - Tue, 21 Jun 2016 14:13:28 GMT
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="utf-8"?><s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header><h:ServerVersionInfo
@@ -69,5 +69,5 @@ http_interactions:
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"><m:ResponseMessages><m:DeleteItemResponseMessage
         ResponseClass="Success"><m:ResponseCode>NoError</m:ResponseCode></m:DeleteItemResponseMessage></m:ResponseMessages></m:DeleteItemResponse></s:Body></s:Envelope>
     http_version: 
-  recorded_at: Tue, 21 Jun 2016 14:13:14 GMT
+  recorded_at: Tue, 21 Jun 2016 14:13:28 GMT
 recorded_with: VCR 3.0.1

--- a/spec/exchanger/calendar_item_spec.rb
+++ b/spec/exchanger/calendar_item_spec.rb
@@ -1,11 +1,13 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
+SUBJECT = "Test Calendar Item"
+
 describe Exchanger::CalendarItem do
   before do
     @folder = VCR.use_cassette('folder/find_calendar') do
       Exchanger::Folder.find(:calendar)
     end
-    @calendar_item = @folder.new_calendar_item
+    @calendar_item = @folder.new_calendar_item(subject: SUBJECT, body: Exchanger::Body.new(text: "Body line 1.\nBody line 2."), start: Time.now, end: Time.now + 30.minutes)
   end
 
   describe "#save" do
@@ -20,21 +22,45 @@ describe Exchanger::CalendarItem do
     it "should create and update calendar item" do
       VCR.use_cassette("calendar_item/save") do
         prev_items_size = @folder.items.size
-        @calendar_item.subject = "Calendar Item Subject"
-        @calendar_item.body = Exchanger::Body.new(text: "Body line 1.\nBody line 2.")
-        @calendar_item.start = Time.now
-        @calendar_item.end = Time.now + 30.minutes
         @calendar_item.should be_changed
         @calendar_item.save
         @calendar_item.should_not be_new_record
         @calendar_item.should_not be_changed
         @calendar_item.reload
-        @calendar_item.subject.should == "Calendar Item Subject"
+        @calendar_item.subject.should == SUBJECT
         @folder.items.size.should == prev_items_size + 1
-        @calendar_item.subject = "Calendar Item Subject - Updated"
+        @calendar_item.subject += " Updated"
         @calendar_item.should be_changed
         @calendar_item.save
         @calendar_item.should_not be_changed
+      end
+    end
+  end
+
+  describe "#file_attachment" do
+    after do
+      if @calendar_item.persisted?
+        VCR.use_cassette("calendar_item/save_file_attachment_cleanup") do
+          @calendar_item.destroy
+        end
+      end
+    end
+
+    it "should create and read file attachments" do
+      VCR.use_cassette("calendar_item/save_file_attachment") do
+        @calendar_item.save
+
+        content = "Test Content"
+        file_attachment = @calendar_item.new_file_attachment(name: "test.txt", content_type: "text/plain", content: content)
+        file_attachment.save
+
+        @calendar_item.reload  # Pull attachment metadata using GetItem
+        @calendar_item.attachments.size.should == 1
+
+        attachment = Exchanger::Attachment.find(@calendar_item.attachments[0].id)  # Pull attachment content using GetAttachment
+        attachment.content.should == content
+
+        attachment.destroy
       end
     end
   end


### PR DESCRIPTION
This pull request adds the ability to create, read, and delete file attachments.

An ItemAttachment element has also been created to differentiate between the Attachments that are sent in the GetItem response, but item attachments cannot be created at this time.

During this change, I updated the core method `Exchanger::Attributes#attributes=` so that instead of calling `write_attribute` it now calls `public_send` on the attribute setter method.  This was so that attribute overrides are respected:

```ruby
FileAttachment.new(content: "File content here")  # New content value is set with FileAttachment#content= and goes through Base64.encode64
```

This is similar to the behavior of [`ActiveModel::AttributeAssignment#assign_attributes`](https://github.com/rails/rails/blob/master/activemodel/lib/active_model/attribute_assignment.rb).  But please let me know if you see any problems with this.