### PR TITLE
Add message_disposition to messages

### DIFF
--- a/lib/exchanger/elements/message.rb
+++ b/lib/exchanger/elements/message.rb
@@ -20,5 +20,17 @@ module Exchanger
     element :reply_to, :type => [Mailbox]
     element :received_by, :type => SingleRecipient
     element :received_representing, :type => SingleRecipient
+
+    def create_additional_options
+      { message_disposition: "SendAndSaveCopy" }
+    end
+
+    def update_additional_options
+      { message_disposition: "SaveOnly" }
+    end
+
+    def delete_additional_options
+      { message_disposition: "SaveOnly" }
+    end
   end
 end


### PR DESCRIPTION
When attempting to create an email using exchange, it throws the following error:
`MessageDisposition attribute is required`.

This pull request remedies that. Happy to change the default message_dispositions.